### PR TITLE
Add benchmarks for GET non-existing

### DIFF
--- a/java/benchmarks/src/test/java/javabushka/client/Benchmarking.java
+++ b/java/benchmarks/src/test/java/javabushka/client/Benchmarking.java
@@ -6,7 +6,13 @@ import java.util.stream.Collectors;
 import java.util.Collections;
 
 public class Benchmarking {
+    static final int SIZE_GET_KEYSPACE = 3750000;
     static final int SIZE_SET_KEYSPACE = 3000000;
+
+    public static String generateKeyGet() {
+        int range = SIZE_GET_KEYSPACE - SIZE_SET_KEYSPACE;
+        return Math.floor(Math.random() * range + SIZE_SET_KEYSPACE + 1) + "";
+    }
    
     public static String generateKeySet() {
         return (Math.floor(Math.random() * SIZE_SET_KEYSPACE) + 1) + "";

--- a/java/benchmarks/src/test/java/javabushka/client/jedis/JedisClientIT.java
+++ b/java/benchmarks/src/test/java/javabushka/client/jedis/JedisClientIT.java
@@ -61,6 +61,15 @@ public class JedisClientIT {
                 )
             )
         );
+        Benchmarking.printResults(
+            "GET non-existing",
+            Benchmarking.calculateResults(
+                Benchmarking.getLatencies(
+                    iterations,
+                    () -> jedisClient.get(Benchmarking.generateKeyGet())
+                )
+            )
+        );
     }
 }
 

--- a/java/benchmarks/src/test/java/javabushka/client/lettuce/LettuceClientIT.java
+++ b/java/benchmarks/src/test/java/javabushka/client/lettuce/LettuceClientIT.java
@@ -47,5 +47,14 @@ public class LettuceClientIT {
                 )
             )
         );
+        Benchmarking.printResults(
+            "GET non-existing",
+            Benchmarking.calculateResults(
+                Benchmarking.getLatencies(
+                    iterations,
+                    () -> lettuceClient.get(Benchmarking.generateKeyGet())
+                )
+            )
+        );
     }
 }


### PR DESCRIPTION
This PR adds missing benchmarks for GET non-existing, which the Node and Python clients output benchmarks for.