### PR TITLE
Java: add testing tools for mocking Redis Server 

### DIFF
--- a/java/client/src/main/java/glide/connectors/resources/Platform.java
+++ b/java/client/src/main/java/glide/connectors/resources/Platform.java
@@ -92,4 +92,20 @@ public class Platform {
     throw new RuntimeException(
         "Current platform does not have a supported Domain Server Socket Channel class");
   }
+
+  /**
+   * Get a channel class required by Netty to open a server TCP channel.
+   *
+   * @return Return a class, supported by the current native platform.
+   */
+  public static Class<? extends ServerSocketChannel> getServerTcpNettyChannelType() {
+    if (capabilities.isKQueueAvailable()) {
+      return KQueueServerSocketChannel.class;
+    }
+    if (capabilities.isEPollAvailable()) {
+      return EpollServerSocketChannel.class;
+    }
+    throw new RuntimeException(
+        "Current platform does not have a supported TCP Server Socket Channel class");
+  }
 }

--- a/java/client/src/test/java/glide/connection/ConnectionWithRedisMockTests.java
+++ b/java/client/src/test/java/glide/connection/ConnectionWithRedisMockTests.java
@@ -1,0 +1,144 @@
+package glide.connection;
+
+import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import connection_request.ConnectionRequestOuterClass.AuthenticationInfo;
+import connection_request.ConnectionRequestOuterClass.ConnectionRequest;
+import connection_request.ConnectionRequestOuterClass.NodeAddress;
+import glide.connectors.handlers.CallbackDispatcher;
+import glide.connectors.handlers.ChannelHandler;
+import glide.utils.RedisMockTestBase;
+import glide.utils.RedisServerMock;
+import io.netty.handler.codec.redis.RedisMessage;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ConnectionWithRedisMockTests extends RedisMockTestBase {
+
+  @BeforeAll
+  public static void init() {
+    startRedisMock(null);
+  }
+
+  private ChannelHandler channelHandler = null;
+
+  @BeforeEach
+  public void createTestClient() {
+    channelHandler =
+        new ChannelHandler(new CallbackDispatcher(), getSocket());
+  }
+
+  @AfterEach
+  public void closeTestClient() {
+    channelHandler.close();
+  }
+
+  private static ConnectionRequest.Builder createConnectionRequest() {
+    return ConnectionRequest.newBuilder()
+        .addAddresses(
+            NodeAddress.newBuilder().setHost("localhost").setPort(RedisServerMock.PORT).build());
+  }
+
+  @Test
+  @SneakyThrows
+  public void can_connect_with_no_auth() {
+    RedisServerMock.updateServerMock(
+        new RedisServerMock.ServerMockConnectAll() {
+          @Override
+          public RedisMessage reply(String cmd) {
+            return null;
+          }
+        });
+
+    var connectionRequest = createConnectionRequest().build();
+    var connectionResponse = channelHandler.connect(connectionRequest).get();
+    assertAll(
+        () -> assertFalse(connectionResponse.hasClosingError()),
+        () -> assertFalse(connectionResponse.hasRequestError()),
+        () -> assertFalse(connectionResponse.hasRespPointer()));
+  }
+
+  @Test
+  @SneakyThrows
+  public void can_connect_with_two_addresses() {
+    RedisServerMock.updateServerMock(
+        new RedisServerMock.ServerMockConnectAll() {
+          @Override
+          public RedisMessage reply(String cmd) {
+            return null;
+          }
+        });
+
+    var connectionRequest =
+        createConnectionRequest()
+            .addAddresses(NodeAddress.newBuilder().setHost("dummyHost").setPort(42))
+            .build();
+    var connectionResponse = channelHandler.connect(connectionRequest).get();
+    assertAll(
+        () -> assertFalse(connectionResponse.hasClosingError()),
+        () -> assertFalse(connectionResponse.hasRequestError()),
+        () -> assertFalse(connectionResponse.hasRespPointer()));
+  }
+
+  @Test
+  @SneakyThrows
+  public void cant_connect_with_wrong_password() {
+    RedisServerMock.updateServerMock(
+        new RedisServerMock.ServerMockConnectAll() {
+          @Override
+          public RedisMessage reply(String cmd) {
+            return error("NOAUTH");
+          }
+        });
+
+    var connectionRequest =
+        createConnectionRequest()
+            .setAuthenticationInfo(
+                AuthenticationInfo.newBuilder().setUsername("looser").setPassword("wrong").build())
+            .build();
+    var connectionResponse = channelHandler.connect(connectionRequest).get();
+    assertAll(
+        () -> assertFalse(connectionResponse.hasRespPointer()),
+        () -> assertFalse(connectionResponse.hasRequestError()),
+        () -> assertTrue(connectionResponse.hasClosingError()),
+        () -> assertTrue(connectionResponse.getClosingError().contains("authentication failed")));
+  }
+
+  @Test
+  @SneakyThrows
+  public void can_connect_with_right_password() {
+    RedisServerMock.updateServerMock(
+        new RedisServerMock.ServerMockConnectAll() {
+          @Override
+          public RedisMessage reply(String cmd) {
+            if (cmd.equals("AUTH looser p@$$w0rD")) {
+              return OK();
+            }
+            return error("NOAUTH");
+          }
+        });
+
+    var connectionRequest =
+        createConnectionRequest()
+            .setAuthenticationInfo(
+                AuthenticationInfo.newBuilder()
+                    .setUsername("looser")
+                    .setPassword("p@$$w0rD")
+                    .build())
+            .build();
+    var connectionResponse = channelHandler.connect(connectionRequest).get();
+    assertAll(
+        () -> assertFalse(connectionResponse.hasClosingError()),
+        () -> assertFalse(connectionResponse.hasRequestError()),
+        () -> assertFalse(connectionResponse.hasRespPointer()));
+  }
+}

--- a/java/client/src/test/java/glide/utils/RedisMockTestBase.java
+++ b/java/client/src/test/java/glide/utils/RedisMockTestBase.java
@@ -1,0 +1,43 @@
+package glide.utils;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+public class RedisMockTestBase {
+
+  public static boolean started = false;
+
+  @SneakyThrows
+  public static void startRedisMock(RedisServerMock.ServerMock serverMock) {
+    assert !started
+        : "Previous `RedisMock` wasn't stopped. Ensure that your test class inherits"
+        + " `RedisMockTestBase`.";
+    RedisServerMock.start(serverMock);
+    started = true;
+  }
+
+  @BeforeEach
+  public void preTestCheck() {
+    assert started
+        : "You missed to call `startRustCoreLibMock` in a `@BeforeAll` method of your test class"
+        + " inherited from `RedisMockTestBase`.";
+    RedisServerMock.setDebugLogging(false);
+  }
+
+  @AfterEach
+  public void afterTestCheck() {
+    assert !RedisServerMock.failed() : "Error occurred in `RedisMock`";
+  }
+
+  @AfterAll
+  @SneakyThrows
+  public static void stopRedisMock() {
+    assert started
+        : "You missed to call `startRustCoreLibMock` in a `@BeforeAll` method of your test class"
+        + " inherited from `RedisMockTestBase`.";
+    RedisServerMock.stop();
+    started = false;
+  }
+}

--- a/java/client/src/test/java/glide/utils/RedisServerMock.java
+++ b/java/client/src/test/java/glide/utils/RedisServerMock.java
@@ -1,0 +1,214 @@
+package glide.utils;
+
+import glide.connectors.resources.Platform;
+import glide.connectors.resources.ThreadPoolAllocator;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.CodecException;
+import io.netty.handler.codec.redis.ArrayRedisMessage;
+import io.netty.handler.codec.redis.ErrorRedisMessage;
+import io.netty.handler.codec.redis.FullBulkStringRedisMessage;
+import io.netty.handler.codec.redis.IntegerRedisMessage;
+import io.netty.handler.codec.redis.RedisArrayAggregator;
+import io.netty.handler.codec.redis.RedisBulkStringAggregator;
+import io.netty.handler.codec.redis.RedisDecoder;
+import io.netty.handler.codec.redis.RedisEncoder;
+import io.netty.handler.codec.redis.RedisMessage;
+import io.netty.handler.codec.redis.SimpleStringRedisMessage;
+import io.netty.util.CharsetUtil;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import lombok.Setter;
+
+public class RedisServerMock {
+
+  public abstract static class ServerMock {
+    /** Return `null` to do not reply. */
+    public abstract RedisMessage reply(String cmd);
+
+    protected RedisMessage reply0(String cmd) {
+      return reply(cmd);
+    }
+
+    public static RedisMessage error(String text) {
+      return new ErrorRedisMessage(text);
+    }
+
+    public static RedisMessage error(String prefix, String text) {
+      // https://redis.io/docs/reference/protocol-spec/#simple-errors
+      if (prefix.contains(" ") || prefix.contains("\r") || prefix.contains("\n")) {
+        throw new IllegalArgumentException();
+      }
+      return new ErrorRedisMessage(prefix.toUpperCase() + " " + text);
+    }
+
+    public static RedisMessage simpleString(String text) {
+      return new SimpleStringRedisMessage(text);
+    }
+
+    public static RedisMessage OK() {
+      return simpleString("OK");
+    }
+
+    public static RedisMessage number(long value) {
+      return new IntegerRedisMessage(value);
+    }
+
+    /** A multi-line message. */
+    public static RedisMessage multiString(String text) {
+      return new FullBulkStringRedisMessage(Unpooled.copiedBuffer(text.getBytes()));
+    }
+  }
+
+  public abstract static class ServerMockConnectAll extends ServerMock {
+    @Override
+    protected RedisMessage reply0(String cmd) {
+      if (cmd.startsWith("CLIENT SETINFO")) {
+        return OK();
+      } else if (cmd.startsWith("INFO REPLICATION")) {
+        var response =
+            "# Replication\r\n"
+                + "role:master\r\n"
+                + "connected_slaves:0\r\n"
+                + "master_failover_state:no-failover\r\n"
+                + "master_replid:d7646c8d14901de9347f1f675c70bcf269a503eb\r\n"
+                + "master_replid2:0000000000000000000000000000000000000000\r\n"
+                + "master_repl_offset:0\r\n"
+                + "second_repl_offset:-1\r\n"
+                + "repl_backlog_active:0\r\n"
+                + "repl_backlog_size:1048576\r\n"
+                + "repl_backlog_first_byte_offset:0\r\n"
+                + "repl_backlog_histlen:0\r\n";
+        return multiString(response);
+      }
+      return reply(cmd);
+    }
+  }
+
+  // TODO support configurable port to test cluster mode
+  public static final int PORT = 6380;
+
+  /** Thread pool supplied to <em>Netty</em> to perform all async IO. */
+  private EventLoopGroup group;
+
+  private Channel channel;
+
+  private static RedisServerMock instance;
+
+  private ServerMock messageProcessor;
+
+  /** Update {@link ServerMock} into a running {@link RedisServerMock}. */
+  public static void updateServerMock(ServerMock newMock) {
+    instance.messageProcessor = newMock;
+  }
+
+  private final AtomicBoolean failed = new AtomicBoolean(false);
+
+  /** Get and clear failure status. */
+  public static boolean failed() {
+    return instance.failed.compareAndSet(true, false);
+  }
+
+  @Setter private static boolean debugLogging = false;
+
+  private RedisServerMock() {
+    group = ThreadPoolAllocator.createOrGetNettyThreadPool("RedisMock", Optional.empty());
+    channel =
+        new ServerBootstrap()
+            .group(group)
+            .channel(Platform.getServerTcpNettyChannelType())
+            .childHandler(
+                new ChannelInitializer<SocketChannel>() {
+                  @Override
+                  protected void initChannel(SocketChannel ch) throws Exception {
+                    ch.pipeline()
+                        // https://github.com/netty/netty/blob/4.1/example/src/main/java/io/netty/example/redis/RedisClient.java
+                        .addLast(new RedisDecoder())
+                        .addLast(new RedisBulkStringAggregator())
+                        .addLast(new RedisArrayAggregator())
+                        .addLast(new RedisEncoder())
+                        .addLast(
+                            new ChannelInboundHandlerAdapter() {
+                              @Override
+                              public void channelRead(ChannelHandlerContext ctx, Object msg)
+                                  throws Exception {
+                                RedisMessage redisMessage = (RedisMessage) msg;
+                                var str = RedisMessageToString(redisMessage);
+                                if (debugLogging) {
+                                  System.out.printf("-- Received%n  %s%n", str);
+                                }
+                                var response = messageProcessor.reply0(str);
+                                if (response != null) {
+                                  if (debugLogging) {
+                                    System.out.printf(
+                                        "-- Replying with%n  %s%n", RedisMessageToString(response));
+                                  }
+                                  ctx.writeAndFlush(response);
+                                } else if (debugLogging) {
+                                  System.out.printf("-- Ignoring%n");
+                                }
+                              }
+
+                              @Override
+                              public void exceptionCaught(
+                                  ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                                cause.printStackTrace();
+                                ctx.close();
+                                failed.setPlain(true);
+                              }
+                            });
+                  }
+                })
+            .bind(new InetSocketAddress(PORT))
+            .syncUninterruptibly()
+            .channel();
+  }
+
+  public static void start(ServerMock messageProcessor) {
+    if (instance != null) {
+      stop();
+    }
+    instance = new RedisServerMock();
+    instance.messageProcessor = messageProcessor;
+  }
+
+  public static void stop() {
+    instance.channel.close();
+    instance.group.shutdownGracefully();
+    instance = null;
+  }
+
+  private static String RedisMessageToString(RedisMessage msg) {
+    if (msg instanceof SimpleStringRedisMessage) {
+      return ((SimpleStringRedisMessage) msg).content();
+    } else if (msg instanceof ErrorRedisMessage) {
+      return ((ErrorRedisMessage) msg).content();
+    } else if (msg instanceof IntegerRedisMessage) {
+      return String.valueOf(((IntegerRedisMessage) msg).value());
+    } else if (msg instanceof FullBulkStringRedisMessage) {
+      return getString((FullBulkStringRedisMessage) msg);
+    } else if (msg instanceof ArrayRedisMessage) {
+      return ((ArrayRedisMessage) msg)
+          .children().stream()
+          .map(RedisServerMock::RedisMessageToString)
+          .collect(Collectors.joining(" "));
+    } else {
+      throw new CodecException("unknown message type: " + msg);
+    }
+  }
+
+  private static String getString(FullBulkStringRedisMessage msg) {
+    if (msg.isNull()) {
+      return "(null)";
+    }
+    return msg.content().toString(CharsetUtil.UTF_8);
+  }
+}


### PR DESCRIPTION
### Description 

Mock Testing of the Redis service on localhost. 

Diagram: See the middle-track of: 
![part3](https://github.com/Bit-Quill/babushka/assets/88679692/f0349e03-52c8-43dc-945a-41ec4390b5ba)

This PR includes:
1. Redis mock. It allows Glide to connect to it instead of real Redis. Useful for testing some scenarios without deploying/configuring a real Redis.

To run tests use
```ps
./gradlew :client:test --tests ConnectionWithRedisMockTests
./gradlew :client:test
```