### PR TITLE
Add cluster client, request routes configuration and support for bulk response

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -12,8 +12,8 @@ import response.ResponseOuterClass.Response;
 @AllArgsConstructor
 public abstract class BaseClient implements AutoCloseable {
 
-    protected ConnectionManager connectionManager;
-    protected CommandManager commandManager;
+    protected final ConnectionManager connectionManager;
+    protected final CommandManager commandManager;
 
     /**
      * Extracts the response from the Protobuf response and either throws an exception or returns the
@@ -22,10 +22,9 @@ public abstract class BaseClient implements AutoCloseable {
      * @param response Redis protobuf message
      * @return Response Object
      */
-    protected static Object handleObjectResponse(Response response) {
-        // return function to convert protobuf.Response into the response object by
-        // calling valueFromPointer
-        return (new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer)).apply(response);
+    protected Object handleObjectResponse(Response response) {
+        // convert protobuf response into Object and then Object into T
+        return new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer).apply(response);
     }
 
     /**

--- a/java/client/src/main/java/glide/api/ClusterClient.java
+++ b/java/client/src/main/java/glide/api/ClusterClient.java
@@ -1,0 +1,59 @@
+package glide.api;
+
+import static glide.api.RedisClient.buildChannelHandler;
+import static glide.api.RedisClient.buildCommandManager;
+import static glide.api.RedisClient.buildConnectionManager;
+
+import glide.api.commands.ClusterBaseCommands;
+import glide.api.commands.Command;
+import glide.api.models.ClusterValue;
+import glide.api.models.configuration.RedisClusterClientConfiguration;
+import glide.api.models.configuration.Route;
+import glide.connectors.handlers.ChannelHandler;
+import glide.managers.CommandManager;
+import glide.managers.ConnectionManager;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Async (non-blocking) client for Redis in Cluster mode. Use {@link #CreateClient} to request a
+ * client to Redis.
+ */
+public class ClusterClient extends BaseClient implements ClusterBaseCommands<ClusterValue<Object>> {
+
+    protected ClusterClient(ConnectionManager connectionManager, CommandManager commandManager) {
+        super(connectionManager, commandManager);
+    }
+
+    /**
+     * Async request for an async (non-blocking) Redis client in Cluster mode.
+     *
+     * @param config Redis cluster client Configuration
+     * @return a Future to connect and return a ClusterClient
+     */
+    public static CompletableFuture<ClusterClient> CreateClient(
+            RedisClusterClientConfiguration config) {
+        ChannelHandler channelHandler = buildChannelHandler();
+        ConnectionManager connectionManager = buildConnectionManager(channelHandler);
+        CommandManager commandManager = buildCommandManager(channelHandler);
+        // TODO: Support exception throwing, including interrupted exceptions
+        return connectionManager
+                .connectToRedis(config)
+                .thenApply(ignored -> new ClusterClient(connectionManager, commandManager));
+    }
+
+    @Override
+    public CompletableFuture<ClusterValue<Object>> customCommand(String[] args) {
+        Command command =
+                Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
+        return commandManager.submitNewCommand(
+                command, response -> ClusterValue.of(handleObjectResponse(response)));
+    }
+
+    @Override
+    public CompletableFuture<ClusterValue<Object>> customCommand(String[] args, Route route) {
+        Command command =
+                Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
+        return commandManager.submitNewCommand(
+                command, route, response -> ClusterValue.of(handleObjectResponse(response)));
+    }
+}

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -12,15 +12,19 @@ import glide.managers.models.Command;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Async (non-blocking) client for Redis in Standalone mode. Use {@link
- * #CreateClient(RedisClientConfiguration)} to request a client to Redis.
+ * Async (non-blocking) client for Redis in Standalone mode. Use {@link #CreateClient} to request a
+ * client to Redis.
  */
-public class RedisClient extends BaseClient implements BaseCommands {
+public class RedisClient extends BaseClient implements BaseCommands<Object> {
+
+    protected RedisClient(ConnectionManager connectionManager, CommandManager commandManager) {
+        super(connectionManager, commandManager);
+    }
 
     /**
-     * Request an async (non-blocking) Redis client in Standalone mode.
+     * Async request for an async (non-blocking) Redis client in Standalone mode.
      *
-     * @param config - Redis Client Configuration
+     * @param config Redis client Configuration
      * @return a Future to connect and return a RedisClient
      */
     public static CompletableFuture<RedisClient> CreateClient(RedisClientConfiguration config) {
@@ -53,10 +57,6 @@ public class RedisClient extends BaseClient implements BaseCommands {
         return new CommandManager(channelHandler);
     }
 
-    protected RedisClient(ConnectionManager connectionManager, CommandManager commandManager) {
-        super(connectionManager, commandManager);
-    }
-
     /**
      * Executes a single command, without checking inputs. Every part of the command, including
      * subcommands, should be added as a separate value in args.
@@ -73,9 +73,10 @@ public class RedisClient extends BaseClient implements BaseCommands {
      * @param args arguments for the custom command
      * @return a CompletableFuture with response result from Redis
      */
+    @Override
     public CompletableFuture<Object> customCommand(String[] args) {
-        Command command =
-                Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
-        return commandManager.submitNewCommand(command, BaseClient::handleObjectResponse);
+      Command command =
+          Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
+      return commandManager.submitNewCommand(command, BaseClient::handleObjectResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -15,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
  * Async (non-blocking) client for Redis in Standalone mode. Use {@link #CreateClient} to request a
  * client to Redis.
  */
-public class RedisClient extends BaseClient implements BaseCommands<Object> {
+public class RedisClient extends BaseClient implements BaseCommands {
 
     protected RedisClient(ConnectionManager connectionManager, CommandManager commandManager) {
         super(connectionManager, commandManager);

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -9,6 +9,7 @@ import glide.connectors.handlers.ChannelHandler;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
 import glide.managers.models.Command;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -61,6 +62,6 @@ public class RedisClient extends BaseClient implements BaseCommands {
     public CompletableFuture<Object> customCommand(String[] args) {
         Command command =
                 Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
-        return commandManager.submitNewCommand(command, this::handleObjectResponse);
+        return commandManager.submitNewCommand(command, Optional.empty(), this::handleObjectResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -57,26 +57,10 @@ public class RedisClient extends BaseClient implements BaseCommands<Object> {
         return new CommandManager(channelHandler);
     }
 
-    /**
-     * Executes a single command, without checking inputs. Every part of the command, including
-     * subcommands, should be added as a separate value in args.
-     *
-     * @remarks This function should only be used for single-response commands. Commands that don't
-     *     return response (such as SUBSCRIBE), or that return potentially more than a single response
-     *     (such as XREAD), or that change the client's behavior (such as entering pub/sub mode on
-     *     RESP2 connections) shouldn't be called using this function.
-     * @example Returns a list of all pub/sub clients:
-     *     <pre>
-     * Object result = client.customCommand(new String[]{"CLIENT","LIST","TYPE", "PUBSUB"}).get();
-     * </pre>
-     *
-     * @param args arguments for the custom command
-     * @return a CompletableFuture with response result from Redis
-     */
     @Override
     public CompletableFuture<Object> customCommand(String[] args) {
-      Command command =
-          Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
-      return commandManager.submitNewCommand(command, BaseClient::handleObjectResponse);
+        Command command =
+                Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
+        return commandManager.submitNewCommand(command, this::handleObjectResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -18,9 +18,9 @@ import java.util.concurrent.CompletableFuture;
  * Async (non-blocking) client for Redis in Cluster mode. Use {@link #CreateClient} to request a
  * client to Redis.
  */
-public class ClusterClient extends BaseClient implements ClusterBaseCommands<ClusterValue<Object>> {
+public class RedisClusterClient extends BaseClient implements ClusterBaseCommands {
 
-    protected ClusterClient(ConnectionManager connectionManager, CommandManager commandManager) {
+    protected RedisClusterClient(ConnectionManager connectionManager, CommandManager commandManager) {
         super(connectionManager, commandManager);
     }
 
@@ -30,7 +30,7 @@ public class ClusterClient extends BaseClient implements ClusterBaseCommands<Clu
      * @param config Redis cluster client Configuration
      * @return a Future to connect and return a ClusterClient
      */
-    public static CompletableFuture<ClusterClient> CreateClient(
+    public static CompletableFuture<RedisClusterClient> CreateClient(
             RedisClusterClientConfiguration config) {
         try {
             ChannelHandler channelHandler = buildChannelHandler();
@@ -39,10 +39,10 @@ public class ClusterClient extends BaseClient implements ClusterBaseCommands<Clu
             // TODO: Support exception throwing, including interrupted exceptions
             return connectionManager
                     .connectToRedis(config)
-                    .thenApply(ignored -> new ClusterClient(connectionManager, commandManager));
+                    .thenApply(ignored -> new RedisClusterClient(connectionManager, commandManager));
         } catch (InterruptedException e) {
             // Something bad happened while we were establishing netty connection to UDS
-            var future = new CompletableFuture<ClusterClient>();
+            var future = new CompletableFuture<RedisClusterClient>();
             future.completeExceptionally(e);
             return future;
         }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -12,6 +12,7 @@ import glide.connectors.handlers.ChannelHandler;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
 import glide.managers.models.Command;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -53,7 +54,7 @@ public class RedisClusterClient extends BaseClient implements ClusterBaseCommand
         Command command =
                 Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
         return commandManager.submitNewCommand(
-                command, response -> ClusterValue.of(handleObjectResponse(response)));
+                command, Optional.empty(), response -> ClusterValue.of(handleObjectResponse(response)));
     }
 
     @Override
@@ -61,6 +62,6 @@ public class RedisClusterClient extends BaseClient implements ClusterBaseCommand
         Command command =
                 Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
         return commandManager.submitNewCommand(
-                command, route, response -> ClusterValue.of(handleObjectResponse(response)));
+                command, Optional.of(route), response -> ClusterValue.of(handleObjectResponse(response)));
     }
 }

--- a/java/client/src/main/java/glide/api/commands/BaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommands.java
@@ -22,7 +22,7 @@ public interface BaseCommands<T> {
      *     <p><code>
      * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();
      * </code>
-     * @param args Arguments for the custom command
+     * @param args Arguments for the custom command including the command name
      * @return A <em>CompletableFuture</em> with response result from Redis
      */
     CompletableFuture<T> customCommand(String[] args);

--- a/java/client/src/main/java/glide/api/commands/BaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommands.java
@@ -2,12 +2,8 @@ package glide.api.commands;
 
 import java.util.concurrent.CompletableFuture;
 
-/**
- * Base Commands interface to handle generic command and transaction requests.
- *
- * @param <T> The data return type.
- */
-public interface BaseCommands<T> {
+/** Base Commands interface to handle generic command and transaction requests. */
+public interface BaseCommands {
 
     /**
      * Executes a single command, without checking inputs. Every part of the command, including
@@ -25,5 +21,5 @@ public interface BaseCommands<T> {
      * @param args Arguments for the custom command including the command name
      * @return A <em>CompletableFuture</em> with response result from Redis
      */
-    CompletableFuture<T> customCommand(String[] args);
+    CompletableFuture<Object> customCommand(String[] args);
 }

--- a/java/client/src/main/java/glide/api/commands/BaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommands.java
@@ -2,8 +2,12 @@ package glide.api.commands;
 
 import java.util.concurrent.CompletableFuture;
 
-/** Base Commands interface to handle generic command and transaction requests. */
-public interface BaseCommands {
+/**
+ * Base Commands interface to handle generic command and transaction requests.
+ *
+ * @param <T> The data return type.
+ */
+public interface BaseCommands<T> {
 
     /**
      * Executes a single command, without checking inputs. Every part of the command, including
@@ -21,5 +25,5 @@ public interface BaseCommands {
      * @param args arguments for the custom command
      * @return a CompletableFuture with response result from Redis
      */
-    CompletableFuture<Object> customCommand(String[] args);
+    CompletableFuture<T> customCommand(String[] args);
 }

--- a/java/client/src/main/java/glide/api/commands/BaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommands.java
@@ -11,19 +11,19 @@ public interface BaseCommands<T> {
 
     /**
      * Executes a single command, without checking inputs. Every part of the command, including
-     * subcommands, should be added as a separate value in args.
+     * subcommands, should be added as a separate value in {@code args}.
      *
      * @remarks This function should only be used for single-response commands. Commands that don't
-     *     return response (such as SUBSCRIBE), or that return potentially more than a single response
-     *     (such as XREAD), or that change the client's behavior (such as entering pub/sub mode on
-     *     RESP2 connections) shouldn't be called using this function.
-     * @example Returns a list of all pub/sub clients:
-     *     <pre>
-     * Object result = client.customCommand(new String[]{"CLIENT","LIST","TYPE", "PUBSUB"}).get();
-     * </pre>
-     *
-     * @param args arguments for the custom command
-     * @return a CompletableFuture with response result from Redis
+     *     return response (such as <em>SUBSCRIBE</em>), or that return potentially more than a single
+     *     response (such as <em>XREAD</em>), or that change the client's behavior (such as entering
+     *     <em>pub</em>/<em>sub</em> mode on <em>RESP2</em> connections) shouldn't be called using
+     *     this function.
+     * @example Returns a list of all <em>pub</em>/<em>sub</em> clients:
+     *     <p><code>
+     * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();
+     * </code>
+     * @param args Arguments for the custom command
+     * @return A <em>CompletableFuture</em> with response result from Redis
      */
     CompletableFuture<T> customCommand(String[] args);
 }

--- a/java/client/src/main/java/glide/api/commands/ClusterBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ClusterBaseCommands.java
@@ -1,14 +1,31 @@
 package glide.api.commands;
 
+import glide.api.models.ClusterValue;
 import glide.api.models.configuration.Route;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Base Commands interface to handle generic command and transaction requests with routing options.
- *
- * @param <T> The data return type.
  */
-public interface ClusterBaseCommands<T> extends BaseCommands<T> {
+public interface ClusterBaseCommands {
+
+    /**
+     * Executes a single command, without checking inputs. Every part of the command, including
+     * subcommands, should be added as a separate value in {@code args}.
+     *
+     * @remarks This function should only be used for single-response commands. Commands that don't
+     *     return response (such as <em>SUBSCRIBE</em>), or that return potentially more than a single
+     *     response (such as <em>XREAD</em>), or that change the client's behavior (such as entering
+     *     <em>pub</em>/<em>sub</em> mode on <em>RESP2</em> connections) shouldn't be called using
+     *     this function.
+     * @example Returns a list of all <em>pub</em>/<em>sub</em> clients:
+     *     <p><code>
+     * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();
+     * </code>
+     * @param args Arguments for the custom command including the command name
+     * @return A <em>CompletableFuture</em> with response result from Redis
+     */
+    CompletableFuture<ClusterValue<Object>> customCommand(String[] args);
 
     /**
      * Executes a single command, without checking inputs. Every part of the command, including
@@ -27,5 +44,5 @@ public interface ClusterBaseCommands<T> extends BaseCommands<T> {
      * @param route Routing configuration for the command
      * @return A <em>CompletableFuture</em> with response result from Redis
      */
-    CompletableFuture<T> customCommand(String[] args, Route route);
+    CompletableFuture<ClusterValue<Object>> customCommand(String[] args, Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ClusterBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ClusterBaseCommands.java
@@ -11,12 +11,21 @@ import java.util.concurrent.CompletableFuture;
 public interface ClusterBaseCommands<T> extends BaseCommands<T> {
 
     /**
-     * Executes a single custom command, without checking inputs. Every part of the command, including
-     * subcommands, should be added as a separate value in args.
+     * Executes a single command, without checking inputs. Every part of the command, including
+     * subcommands, should be added as a separate value in {@code args}.
      *
-     * @param args command and arguments for the custom command call
-     * @param route node routing configuration for the command
-     * @return CompletableFuture with the response
+     * @remarks This function should only be used for single-response commands. Commands that don't
+     *     return response (such as <em>SUBSCRIBE</em>), or that return potentially more than a single
+     *     response (such as <em>XREAD</em>), or that change the client's behavior (such as entering
+     *     <em>pub</em>/<em>sub</em> mode on <em>RESP2</em> connections) shouldn't be called using
+     *     this function.
+     * @example Returns a list of all <em>pub</em>/<em>sub</em> clients:
+     *     <p><code>
+     * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();
+     * </code>
+     * @param args Arguments for the custom command
+     * @param route Routing configuration for the command
+     * @return A <em>CompletableFuture</em> with response result from Redis
      */
     CompletableFuture<T> customCommand(String[] args, Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ClusterBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ClusterBaseCommands.java
@@ -23,7 +23,7 @@ public interface ClusterBaseCommands<T> extends BaseCommands<T> {
      *     <p><code>
      * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();
      * </code>
-     * @param args Arguments for the custom command
+     * @param args Arguments for the custom command including the command name
      * @param route Routing configuration for the command
      * @return A <em>CompletableFuture</em> with response result from Redis
      */

--- a/java/client/src/main/java/glide/api/commands/ClusterBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ClusterBaseCommands.java
@@ -1,0 +1,22 @@
+package glide.api.commands;
+
+import glide.api.models.configuration.Route;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Base Commands interface to handle generic command and transaction requests with routing options.
+ *
+ * @param <T> The data return type.
+ */
+public interface ClusterBaseCommands<T> extends BaseCommands<T> {
+
+    /**
+     * Executes a single custom command, without checking inputs. Every part of the command, including
+     * subcommands, should be added as a separate value in args.
+     *
+     * @param args command and arguments for the custom command call
+     * @param route node routing configuration for the command
+     * @return CompletableFuture with the response
+     */
+    CompletableFuture<T> customCommand(String[] args, Route route);
+}

--- a/java/client/src/main/java/glide/api/models/ClusterValue.java
+++ b/java/client/src/main/java/glide/api/models/ClusterValue.java
@@ -3,7 +3,9 @@ package glide.api.models;
 import java.util.Map;
 
 /**
- * A union-like type which can store single or bulk value retrieved from Redis.
+ * union-like type which can store single-value or multi-value retrieved from Redis. The
+ * multi-value, if defined, contains the routed value as a Map<String, Object> containing a cluster
+ * node address to cluster node value.
  *
  * @param <T> The wrapped data type
  */
@@ -14,18 +16,25 @@ public class ClusterValue<T> {
 
     private ClusterValue() {}
 
-    /** Get per-node value. */
+    /**
+     * Get per-node value.<br>
+     * Check with {@link #hasMultiData()} prior to accessing the data.
+     */
     public Map<String, T> getMultiValue() {
         assert hasMultiData();
         return multiValue;
     }
 
-    /** Get the single value. */
+    /**
+     * Get the single value.<br>
+     * Check with {@link #hasSingleData()} ()} prior to accessing the data.
+     */
     public T getSingleValue() {
-        assert !hasMultiData();
+        assert hasSingleData();
         return singleValue;
     }
 
+    /** A constructor for the value. */
     @SuppressWarnings("unchecked")
     public static <T> ClusterValue<T> of(Object data) {
         var res = new ClusterValue<T>();
@@ -37,8 +46,13 @@ public class ClusterValue<T> {
         return res;
     }
 
-    /** Get the value type. Use it prior to accessing the data. */
+    /** Check that multi-value is stored in this object. Use it prior to accessing the data. */
     public boolean hasMultiData() {
         return multiValue != null;
+    }
+
+    /** Check that single-value is stored in this object. Use it prior to accessing the data. */
+    public boolean hasSingleData() {
+        return !hasMultiData();
     }
 }

--- a/java/client/src/main/java/glide/api/models/ClusterValue.java
+++ b/java/client/src/main/java/glide/api/models/ClusterValue.java
@@ -1,0 +1,44 @@
+package glide.api.models;
+
+import java.util.Map;
+
+/**
+ * A union-like type which can store single or bulk value retrieved from Redis.
+ *
+ * @param <T> The wrapped data type
+ */
+public class ClusterValue<T> {
+    /** Get per-node value. */
+    private Map<String, T> multiValue = null;
+
+    /** Get the single value. */
+    private T singleValue = null;
+
+    private ClusterValue() {}
+
+    public Map<String, T> getMultiValue() {
+        assert hasMultiData();
+        return multiValue;
+    }
+
+    public T getSingleValue() {
+        assert !hasMultiData();
+        return singleValue;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> ClusterValue<T> of(Object data) {
+        var res = new ClusterValue<T>();
+        if (data instanceof Map) {
+            res.multiValue = (Map<String, T>) data;
+        } else {
+            res.singleValue = (T) data;
+        }
+        return res;
+    }
+
+    /** Get the value type. Use it prior to accessing the data. */
+    public boolean hasMultiData() {
+        return multiValue != null;
+    }
+}

--- a/java/client/src/main/java/glide/api/models/ClusterValue.java
+++ b/java/client/src/main/java/glide/api/models/ClusterValue.java
@@ -8,19 +8,19 @@ import java.util.Map;
  * @param <T> The wrapped data type
  */
 public class ClusterValue<T> {
-    /** Get per-node value. */
     private Map<String, T> multiValue = null;
 
-    /** Get the single value. */
     private T singleValue = null;
 
     private ClusterValue() {}
 
+    /** Get per-node value. */
     public Map<String, T> getMultiValue() {
         assert hasMultiData();
         return multiValue;
     }
 
+    /** Get the single value. */
     public T getSingleValue() {
         assert !hasMultiData();
         return singleValue;

--- a/java/client/src/main/java/glide/api/models/configuration/Route.java
+++ b/java/client/src/main/java/glide/api/models/configuration/Route.java
@@ -1,13 +1,10 @@
 package glide.api.models.configuration;
 
-import lombok.AccessLevel;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /** Request routing configuration. */
-@Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Route {
 
     public enum RouteType {
@@ -27,29 +24,40 @@ public class Route {
         REPLICA_SLOT_KEY,
     }
 
-    /**
-     * Request routing configuration overrides the {@link ReadFrom} connection configuration.<br>
-     * If {@link RouteType#REPLICA_SLOT_ID} or {@link RouteType#REPLICA_SLOT_KEY} is used, the request
-     * will be routed to a replica, even if the strategy is {@link ReadFrom#PRIMARY}.
-     */
-    private final RouteType routeType;
+    @Getter private final RouteType routeType;
 
-    /**
-     * Slot number. There are 16384 slots in a redis cluster, and each shard manages a slot range.
-     * Unless the slot is known, it's better to route using {@link RouteType#PRIMARY_SLOT_KEY} or
-     * {@link RouteType#REPLICA_SLOT_KEY}.<br>
-     * Could be used with {@link RouteType#PRIMARY_SLOT_ID} or {@link RouteType#REPLICA_SLOT_ID} only.
-     */
-    private final int slotId;
+    private final Optional<Integer> slotId;
 
-    /**
-     * The request will be sent to nodes managing this key.<br>
-     * Could be used with {@link RouteType#PRIMARY_SLOT_KEY} or {@link RouteType#REPLICA_SLOT_KEY}
-     * only.
-     */
-    private final String slotKey;
+    private final Optional<String> slotKey;
 
-    @RequiredArgsConstructor
+    public Integer getSlotId() {
+        assert slotId.isPresent();
+        return slotId.get();
+    }
+
+    public String getSlotKey() {
+        assert slotKey.isPresent();
+        return slotKey.get();
+    }
+
+    private Route(RouteType routeType, Integer slotId) {
+        this.routeType = routeType;
+        this.slotId = Optional.of(slotId);
+        this.slotKey = Optional.empty();
+    }
+
+    private Route(RouteType routeType, String slotKey) {
+        this.routeType = routeType;
+        this.slotId = Optional.empty();
+        this.slotKey = Optional.of(slotKey);
+    }
+
+    private Route(RouteType routeType) {
+        this.routeType = routeType;
+        this.slotId = Optional.empty();
+        this.slotKey = Optional.empty();
+    }
+
     public static class Builder {
         private final RouteType routeType;
         private int slotId;
@@ -57,6 +65,22 @@ public class Route {
         private String slotKey;
         private boolean slotKeySet = false;
 
+        /**
+         * Request routing configuration overrides the {@link ReadFrom} connection configuration.<br>
+         * If {@link RouteType#REPLICA_SLOT_ID} or {@link RouteType#REPLICA_SLOT_KEY} is used, the
+         * request will be routed to a replica, even if the strategy is {@link ReadFrom#PRIMARY}.
+         */
+        public Builder(RouteType routeType) {
+            this.routeType = routeType;
+        }
+
+        /**
+         * Slot number. There are 16384 slots in a redis cluster, and each shard manages a slot range.
+         * Unless the slot is known, it's better to route using {@link RouteType#PRIMARY_SLOT_KEY} or
+         * {@link RouteType#REPLICA_SLOT_KEY}.<br>
+         * Could be used with {@link RouteType#PRIMARY_SLOT_ID} or {@link RouteType#REPLICA_SLOT_ID}
+         * only.
+         */
         public Builder setSlotId(int slotId) {
             if (!(routeType == RouteType.PRIMARY_SLOT_ID || routeType == RouteType.REPLICA_SLOT_ID)) {
                 throw new IllegalArgumentException(
@@ -67,6 +91,11 @@ public class Route {
             return this;
         }
 
+        /**
+         * The request will be sent to nodes managing this key.<br>
+         * Could be used with {@link RouteType#PRIMARY_SLOT_KEY} or {@link RouteType#REPLICA_SLOT_KEY}
+         * only.
+         */
         public Builder setSlotKey(String slotKey) {
             if (!(routeType == RouteType.PRIMARY_SLOT_KEY || routeType == RouteType.REPLICA_SLOT_KEY)) {
                 throw new IllegalArgumentException(
@@ -78,16 +107,20 @@ public class Route {
         }
 
         public Route build() {
-            if ((routeType == RouteType.PRIMARY_SLOT_ID || routeType == RouteType.REPLICA_SLOT_ID)
-                    && !slotIdSet) {
-                throw new IllegalArgumentException("Slot ID is missing");
+            if (routeType == RouteType.PRIMARY_SLOT_ID || routeType == RouteType.REPLICA_SLOT_ID) {
+                if (!slotIdSet) {
+                    throw new IllegalArgumentException("Slot ID is missing");
+                }
+                return new Route(routeType, slotId);
             }
-            if ((routeType == RouteType.PRIMARY_SLOT_KEY || routeType == RouteType.REPLICA_SLOT_KEY)
-                    && !slotKeySet) {
-                throw new IllegalArgumentException("Slot key is missing");
+            if (routeType == RouteType.PRIMARY_SLOT_KEY || routeType == RouteType.REPLICA_SLOT_KEY) {
+                if (!slotKeySet) {
+                    throw new IllegalArgumentException("Slot key is missing");
+                }
+                return new Route(routeType, slotKey);
             }
 
-            return new Route(routeType, slotId, slotKey);
+            return new Route(routeType);
         }
     }
 }

--- a/java/client/src/main/java/glide/api/models/configuration/Route.java
+++ b/java/client/src/main/java/glide/api/models/configuration/Route.java
@@ -1,0 +1,93 @@
+package glide.api.models.configuration;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** Request routing configuration. */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Route {
+
+    public enum RouteType {
+        /** Route request to all nodes. */
+        ALL_NODES,
+        /** Route request to all primary nodes. */
+        ALL_PRIMARIES,
+        /** Route request to a random node. */
+        RANDOM,
+        /** Route request to the primary node that contains the slot with the given id. */
+        PRIMARY_SLOT_ID,
+        /** Route request to the replica node that contains the slot with the given id. */
+        REPLICA_SLOT_ID,
+        /** Route request to the primary node that contains the slot that the given key matches. */
+        PRIMARY_SLOT_KEY,
+        /** Route request to the replica node that contains the slot that the given key matches. */
+        REPLICA_SLOT_KEY,
+    }
+
+    /**
+     * Request routing configuration overrides the {@link ReadFrom} connection configuration.<br>
+     * If {@link RouteType#REPLICA_SLOT_ID} or {@link RouteType#REPLICA_SLOT_KEY} is used, the request
+     * will be routed to a replica, even if the strategy is {@link ReadFrom#PRIMARY}.
+     */
+    private final RouteType routeType;
+
+    /**
+     * Slot number. There are 16384 slots in a redis cluster, and each shard manages a slot range.
+     * Unless the slot is known, it's better to route using {@link RouteType#PRIMARY_SLOT_KEY} or
+     * {@link RouteType#REPLICA_SLOT_KEY}.<br>
+     * Could be used with {@link RouteType#PRIMARY_SLOT_ID} or {@link RouteType#REPLICA_SLOT_ID} only.
+     */
+    private final int slotId;
+
+    /**
+     * The request will be sent to nodes managing this key.<br>
+     * Could be used with {@link RouteType#PRIMARY_SLOT_KEY} or {@link RouteType#REPLICA_SLOT_KEY}
+     * only.
+     */
+    private final String slotKey;
+
+    @RequiredArgsConstructor
+    public static class Builder {
+        private final RouteType routeType;
+        private int slotId;
+        private boolean slotIdSet = false;
+        private String slotKey;
+        private boolean slotKeySet = false;
+
+        public Builder setSlotId(int slotId) {
+            if (!(routeType == RouteType.PRIMARY_SLOT_ID || routeType == RouteType.REPLICA_SLOT_ID)) {
+                throw new IllegalArgumentException(
+                        "Slot ID could be set for corresponding types of route only");
+            }
+            this.slotId = slotId;
+            slotIdSet = true;
+            return this;
+        }
+
+        public Builder setSlotKey(String slotKey) {
+            if (!(routeType == RouteType.PRIMARY_SLOT_KEY || routeType == RouteType.REPLICA_SLOT_KEY)) {
+                throw new IllegalArgumentException(
+                        "Slot key could be set for corresponding types of route only");
+            }
+            this.slotKey = slotKey;
+            slotKeySet = true;
+            return this;
+        }
+
+        public Route build() {
+            if ((routeType == RouteType.PRIMARY_SLOT_ID || routeType == RouteType.REPLICA_SLOT_ID)
+                    && !slotIdSet) {
+                throw new IllegalArgumentException("Slot ID is missing");
+            }
+            if ((routeType == RouteType.PRIMARY_SLOT_KEY || routeType == RouteType.REPLICA_SLOT_KEY)
+                    && !slotKeySet) {
+                throw new IllegalArgumentException("Slot key is missing");
+            }
+
+            return new Route(routeType, slotId, slotKey);
+        }
+    }
+}

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -7,9 +7,13 @@ import glide.managers.models.Command;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import redis_request.RedisRequestOuterClass;
-import redis_request.RedisRequestOuterClass.RequestType;
 import redis_request.RedisRequestOuterClass.Command.ArgsArray;
 import redis_request.RedisRequestOuterClass.RedisRequest;
+import redis_request.RedisRequestOuterClass.RequestType;
+import redis_request.RedisRequestOuterClass.SimpleRoutes;
+import redis_request.RedisRequestOuterClass.SlotIdRoute;
+import redis_request.RedisRequestOuterClass.SlotKeyRoute;
+import redis_request.RedisRequestOuterClass.SlotTypes;
 import response.ResponseOuterClass.Response;
 
 /**
@@ -79,11 +83,11 @@ public class CommandManager {
     }
 
     private RequestType mapRequestTypes(Command.RequestType inType) {
-      switch (inType) {
-        case CUSTOM_COMMAND:
-          return RequestType.CustomCommand;
-      }
-      throw new RuntimeException("Unsupported request type");
+        switch (inType) {
+            case CUSTOM_COMMAND:
+                return RequestType.CustomCommand;
+        }
+        throw new RuntimeException("Unsupported request type");
     }
 
     /**
@@ -94,7 +98,7 @@ public class CommandManager {
      *     adding a callback id.
      */
     private RedisRequest.Builder prepareRedisRequest(
-        Command.RequestType command, String[] args, Route route) {
+            Command.RequestType command, String[] args, Route route) {
         RedisRequest.Builder builder = prepareRedisRequest(command, args);
 
         switch (route.getRouteType()) {
@@ -111,7 +115,7 @@ public class CommandManager {
                 builder.setRoute(
                         RedisRequestOuterClass.Routes.newBuilder()
                                 .setSlotKeyRoute(
-                                        RedisRequestOuterClass.SlotKeyRoute.newBuilder()
+                                        SlotKeyRoute.newBuilder()
                                                 .setSlotKey(route.getSlotKey())
                                                 .setSlotType(getSlotTypes(route.getRouteType()))));
                 break;
@@ -120,33 +124,33 @@ public class CommandManager {
                 builder.setRoute(
                         RedisRequestOuterClass.Routes.newBuilder()
                                 .setSlotIdRoute(
-                                        RedisRequestOuterClass.SlotIdRoute.newBuilder()
+                                        SlotIdRoute.newBuilder()
                                                 .setSlotId(route.getSlotId())
                                                 .setSlotType(getSlotTypes(route.getRouteType()))));
         }
         return builder;
     }
 
-    private RedisRequestOuterClass.SimpleRoutes getSimpleRoutes(Route.RouteType routeType) {
+    private SimpleRoutes getSimpleRoutes(Route.RouteType routeType) {
         switch (routeType) {
             case RANDOM:
-                return RedisRequestOuterClass.SimpleRoutes.Random;
+                return SimpleRoutes.Random;
             case ALL_NODES:
-                return RedisRequestOuterClass.SimpleRoutes.AllNodes;
+                return SimpleRoutes.AllNodes;
             case ALL_PRIMARIES:
-                return RedisRequestOuterClass.SimpleRoutes.AllPrimaries;
+                return SimpleRoutes.AllPrimaries;
         }
         throw new IllegalStateException("Unreachable code");
     }
 
-    private RedisRequestOuterClass.SlotTypes getSlotTypes(Route.RouteType routeType) {
+    private SlotTypes getSlotTypes(Route.RouteType routeType) {
         switch (routeType) {
             case PRIMARY_SLOT_ID:
             case PRIMARY_SLOT_KEY:
-                return RedisRequestOuterClass.SlotTypes.Primary;
+                return SlotTypes.Primary;
             case REPLICA_SLOT_ID:
             case REPLICA_SLOT_KEY:
-                return RedisRequestOuterClass.SlotTypes.Replica;
+                return SlotTypes.Replica;
         }
         throw new IllegalStateException("Unreachable code");
     }

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -1,11 +1,15 @@
 package glide.managers;
 
+import glide.api.models.configuration.Route;
+import glide.connectors.handlers.CallbackDispatcher;
 import glide.connectors.handlers.ChannelHandler;
 import glide.managers.models.Command;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import redis_request.RedisRequestOuterClass;
 import redis_request.RedisRequestOuterClass.RequestType;
+import redis_request.RedisRequestOuterClass.Command.ArgsArray;
+import redis_request.RedisRequestOuterClass.RedisRequest;
 import response.ResponseOuterClass.Response;
 
 /**
@@ -21,8 +25,8 @@ public class CommandManager {
     /**
      * Build a command and send.
      *
-     * @param command
-     * @param responseHandler - to handle the response object
+     * @param command The command to execute
+     * @param responseHandler The handler for the response object
      * @return A result promise of type T
      */
     public <T> CompletableFuture<T> submitNewCommand(
@@ -31,7 +35,24 @@ public class CommandManager {
         // when complete, convert the response to our expected type T using the given responseHandler
         return channel
                 .write(prepareRedisRequest(command.getRequestType(), command.getArguments()), true)
-                .thenApplyAsync(response -> responseHandler.apply(response));
+                .thenApplyAsync(responseHandler::apply);
+    }
+
+    /**
+     * Build a command and send.
+     *
+     * @param command The command to execute
+     * @param route The routing options
+     * @param responseHandler The handler for the response object
+     * @return A result promise of type T
+     */
+    public <T> CompletableFuture<T> submitNewCommand(
+            Command command, Route route, RedisExceptionCheckedFunction<Response, T> responseHandler) {
+        // write command request to channel
+        // when complete, convert the response to our expected type T using the given responseHandler
+        return channel
+                .write(prepareRedisRequest(command.getRequestType(), command.getArguments(), route), true)
+                .thenApplyAsync(responseHandler::apply);
     }
 
     /**
@@ -40,35 +61,93 @@ public class CommandManager {
      *
      * @param command - Redis command
      * @param args - Redis command arguments as string array
-     * @return An uncompleted request. CallbackDispatcher is responsible to complete it by adding a
-     *     callback id.
+     * @return An uncompleted request. {@link CallbackDispatcher} is responsible to complete it by
+     *     adding a callback id.
      */
-    private RedisRequestOuterClass.RedisRequest.Builder prepareRedisRequest(
-            Command.RequestType command, String[] args) {
-        RedisRequestOuterClass.Command.ArgsArray.Builder commandArgs =
-                RedisRequestOuterClass.Command.ArgsArray.newBuilder();
+    private RedisRequest.Builder prepareRedisRequest(Command.RequestType command, String[] args) {
+        ArgsArray.Builder commandArgs = ArgsArray.newBuilder();
         for (var arg : args) {
             commandArgs.addArgs(arg);
         }
 
-        // TODO: set route properly when no RouteOptions given
-        return RedisRequestOuterClass.RedisRequest.newBuilder()
+        return RedisRequest.newBuilder()
                 .setSingleCommand(
                         RedisRequestOuterClass.Command.newBuilder()
                                 .setRequestType(mapRequestTypes(command))
                                 .setArgsArray(commandArgs.build())
-                                .build())
-                .setRoute(
-                        RedisRequestOuterClass.Routes.newBuilder()
-                                .setSimpleRoutes(RedisRequestOuterClass.SimpleRoutes.AllNodes)
                                 .build());
     }
 
     private RequestType mapRequestTypes(Command.RequestType inType) {
-        switch (inType) {
-            case CUSTOM_COMMAND:
-                return RequestType.CustomCommand;
+      switch (inType) {
+        case CUSTOM_COMMAND:
+          return RequestType.CustomCommand;
+      }
+      throw new RuntimeException("Unsupported request type");
+    }
+
+    /**
+     * Build a protobuf command/transaction request object with routing options.<br>
+     * Used by {@link CommandManager}.
+     *
+     * @return An uncompleted request. {@link CallbackDispatcher} is responsible to complete it by
+     *     adding a callback id.
+     */
+    private RedisRequest.Builder prepareRedisRequest(
+        Command.RequestType command, String[] args, Route route) {
+        RedisRequest.Builder builder = prepareRedisRequest(command, args);
+
+        switch (route.getRouteType()) {
+            case RANDOM:
+            case ALL_NODES:
+            case ALL_PRIMARIES:
+                builder.setRoute(
+                        RedisRequestOuterClass.Routes.newBuilder()
+                                .setSimpleRoutes(getSimpleRoutes(route.getRouteType()))
+                                .build());
+                break;
+            case PRIMARY_SLOT_KEY:
+            case REPLICA_SLOT_KEY:
+                builder.setRoute(
+                        RedisRequestOuterClass.Routes.newBuilder()
+                                .setSlotKeyRoute(
+                                        RedisRequestOuterClass.SlotKeyRoute.newBuilder()
+                                                .setSlotKey(route.getSlotKey())
+                                                .setSlotType(getSlotTypes(route.getRouteType()))));
+                break;
+            case PRIMARY_SLOT_ID:
+            case REPLICA_SLOT_ID:
+                builder.setRoute(
+                        RedisRequestOuterClass.Routes.newBuilder()
+                                .setSlotIdRoute(
+                                        RedisRequestOuterClass.SlotIdRoute.newBuilder()
+                                                .setSlotId(route.getSlotId())
+                                                .setSlotType(getSlotTypes(route.getRouteType()))));
         }
-        throw new RuntimeException("Unsupported request type");
+        return builder;
+    }
+
+    private RedisRequestOuterClass.SimpleRoutes getSimpleRoutes(Route.RouteType routeType) {
+        switch (routeType) {
+            case RANDOM:
+                return RedisRequestOuterClass.SimpleRoutes.Random;
+            case ALL_NODES:
+                return RedisRequestOuterClass.SimpleRoutes.AllNodes;
+            case ALL_PRIMARIES:
+                return RedisRequestOuterClass.SimpleRoutes.AllPrimaries;
+        }
+        throw new IllegalStateException("Unreachable code");
+    }
+
+    private RedisRequestOuterClass.SlotTypes getSlotTypes(Route.RouteType routeType) {
+        switch (routeType) {
+            case PRIMARY_SLOT_ID:
+            case PRIMARY_SLOT_KEY:
+                return RedisRequestOuterClass.SlotTypes.Primary;
+            case REPLICA_SLOT_ID:
+            case REPLICA_SLOT_KEY:
+                return RedisRequestOuterClass.SlotTypes.Replica;
+        }
+        throw new IllegalStateException("Unreachable code");
     }
 }

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -63,8 +63,8 @@ public class CommandManager {
      * Build a protobuf command/transaction request object.<br>
      * Used by {@link CommandManager}.
      *
-     * @param command - Redis command
-     * @param args - Redis command arguments as string array
+     * @param command Redis command type
+     * @param args Redis command arguments
      * @return An uncompleted request. {@link CallbackDispatcher} is responsible to complete it by
      *     adding a callback id.
      */

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -36,7 +36,7 @@ public class RedisClientTest {
         String cmd = "GETSTRING";
         CompletableFuture<Object> testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn(value);
-        when(commandManager.submitNewCommand(any(), any())).thenReturn(testResponse);
+        when(commandManager.submitNewCommand(any(), any(), any())).thenReturn(testResponse);
 
         // exercise
         CompletableFuture<Object> response = service.customCommand(new String[] {cmd, key});
@@ -56,7 +56,7 @@ public class RedisClientTest {
         CompletableFuture<Object> testResponse = mock(CompletableFuture.class);
         InterruptedException interruptedException = new InterruptedException();
         when(testResponse.get()).thenThrow(interruptedException);
-        when(commandManager.submitNewCommand(any(), any())).thenReturn(testResponse);
+        when(commandManager.submitNewCommand(any(), any(), any())).thenReturn(testResponse);
 
         // exercise
         InterruptedException exception =

--- a/java/client/src/test/java/glide/api/models/ClusterValueTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterValueTests.java
@@ -1,0 +1,44 @@
+package glide.api.models;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ClusterValueTests {
+
+    @Test
+    public void handle_null() {
+        var value = ClusterValue.of(null);
+        assertAll(
+                () -> assertFalse(value.hasMultiData()),
+                () -> assertNull(value.getSingleValue()),
+                () -> assertThrows(Throwable.class, value::getMultiValue));
+    }
+
+    @Test
+    public void handle_single_data() {
+        var value = ClusterValue.of(42);
+        assertAll(
+                () -> assertFalse(value.hasMultiData()),
+                () -> assertEquals(42, value.getSingleValue()),
+                () -> assertThrows(Throwable.class, value::getMultiValue));
+    }
+
+    @Test
+    public void handle_multi_data() {
+        var data = Map.of("node1", Map.of("config1", "param1", "config2", "param2"), "node2", Map.of());
+        var value = ClusterValue.of(data);
+        assertAll(
+                () -> assertTrue(value.hasMultiData()),
+                () -> assertNotNull(value.getMultiValue()),
+                () -> assertEquals(data, value.getMultiValue()),
+                () -> assertThrows(Throwable.class, value::getSingleValue));
+    }
+}

--- a/java/client/src/test/java/glide/api/models/ClusterValueTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterValueTests.java
@@ -18,6 +18,7 @@ public class ClusterValueTests {
         var value = ClusterValue.of(null);
         assertAll(
                 () -> assertFalse(value.hasMultiData()),
+                () -> assertTrue(value.hasSingleData()),
                 () -> assertNull(value.getSingleValue()),
                 () -> assertThrows(Throwable.class, value::getMultiValue));
     }
@@ -27,6 +28,7 @@ public class ClusterValueTests {
         var value = ClusterValue.of(42);
         assertAll(
                 () -> assertFalse(value.hasMultiData()),
+                () -> assertTrue(value.hasSingleData()),
                 () -> assertEquals(42, value.getSingleValue()),
                 () -> assertThrows(Throwable.class, value::getMultiValue));
     }
@@ -37,6 +39,7 @@ public class ClusterValueTests {
         var value = ClusterValue.of(data);
         assertAll(
                 () -> assertTrue(value.hasMultiData()),
+                () -> assertFalse(value.hasSingleData()),
                 () -> assertNotNull(value.getMultiValue()),
                 () -> assertEquals(data, value.getMultiValue()),
                 () -> assertThrows(Throwable.class, value::getSingleValue));

--- a/java/client/src/test/java/glide/api/models/RouteBuilderTests.java
+++ b/java/client/src/test/java/glide/api/models/RouteBuilderTests.java
@@ -1,0 +1,93 @@
+package glide.api.models;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import glide.api.models.configuration.Route;
+import glide.api.models.configuration.Route.RouteType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class RouteBuilderTests {
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"PRIMARY_SLOT_ID", "REPLICA_SLOT_ID"})
+    public void slot_id_is_required(RouteType routeType) {
+        var exception =
+                assertThrows(IllegalArgumentException.class, () -> new Route.Builder(routeType).build());
+        assertEquals("Slot ID is missing", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"PRIMARY_SLOT_KEY", "REPLICA_SLOT_KEY"})
+    public void slot_key_is_required(RouteType routeType) {
+        var exception =
+                assertThrows(IllegalArgumentException.class, () -> new Route.Builder(routeType).build());
+        assertEquals("Slot key is missing", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"PRIMARY_SLOT_KEY", "REPLICA_SLOT_KEY", "ALL_NODES", "ALL_PRIMARIES", "RANDOM"})
+    public void slot_id_not_acceptable(RouteType routeType) {
+        var exception =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new Route.Builder(routeType).setSlotId(42));
+        assertEquals(
+                "Slot ID could be set for corresponding types of route only", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"PRIMARY_SLOT_ID", "REPLICA_SLOT_ID", "ALL_NODES", "ALL_PRIMARIES", "RANDOM"})
+    public void slot_key_not_acceptable(RouteType routeType) {
+        var exception =
+                assertThrows(
+                        IllegalArgumentException.class, () -> new Route.Builder(routeType).setSlotKey("D'oh"));
+        assertEquals(
+                "Slot key could be set for corresponding types of route only", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"PRIMARY_SLOT_ID", "REPLICA_SLOT_ID"})
+    public void build_with_slot_id(RouteType routeType) {
+        var route = new Route.Builder(routeType).setSlotId(42).build();
+        assertAll(
+                () -> assertEquals(routeType, route.getRouteType()),
+                () -> assertEquals(42, route.getSlotId()),
+                () -> assertThrows(Throwable.class, () -> route.getSlotKey()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"PRIMARY_SLOT_KEY", "REPLICA_SLOT_KEY"})
+    public void build_with_slot_key(RouteType routeType) {
+        var route = new Route.Builder(routeType).setSlotKey("test").build();
+        assertAll(
+                () -> assertEquals(routeType, route.getRouteType()),
+                () -> assertEquals("test", route.getSlotKey()),
+                () -> assertThrows(Throwable.class, () -> route.getSlotId()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"ALL_NODES", "ALL_PRIMARIES", "RANDOM"})
+    public void build_simple_route(RouteType routeType) {
+        var route = new Route.Builder(routeType).build();
+        assertAll(
+                () -> assertEquals(routeType, route.getRouteType()),
+                () -> assertThrows(Throwable.class, () -> route.getSlotKey()),
+                () -> assertThrows(Throwable.class, () -> route.getSlotId()));
+    }
+}

--- a/java/client/src/test/java/glide/managers/CommandManagerTest.java
+++ b/java/client/src/test/java/glide/managers/CommandManagerTest.java
@@ -25,6 +25,7 @@ import glide.api.models.exceptions.TimeoutException;
 import glide.connectors.handlers.ChannelHandler;
 import glide.managers.models.Command;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +72,9 @@ public class CommandManagerTest {
         // exercise
         CompletableFuture result =
                 service.submitNewCommand(
-                        command, new BaseCommandResponseResolver((ptr) -> ptr == pointer ? respObject : null));
+                        command,
+                        Optional.empty(),
+                        new BaseCommandResponseResolver((ptr) -> ptr == pointer ? respObject : null));
         Object respPointer = result.get();
 
         // verify
@@ -89,7 +92,9 @@ public class CommandManagerTest {
         // exercise
         CompletableFuture result =
                 service.submitNewCommand(
-                        command, new BaseCommandResponseResolver((p) -> new RuntimeException("")));
+                        command,
+                        Optional.empty(),
+                        new BaseCommandResponseResolver((p) -> new RuntimeException("")));
         Object respPointer = result.get();
 
         // verify
@@ -113,7 +118,9 @@ public class CommandManagerTest {
         // exercise
         CompletableFuture result =
                 service.submitNewCommand(
-                        command, new BaseCommandResponseResolver((p) -> p == pointer ? testString : null));
+                        command,
+                        Optional.empty(),
+                        new BaseCommandResponseResolver((p) -> p == pointer ? testString : null));
         Object respPointer = result.get();
 
         // verify
@@ -140,7 +147,9 @@ public class CommandManagerTest {
                         () -> {
                             CompletableFuture result =
                                     service.submitNewCommand(
-                                            command, new BaseCommandResponseResolver((ptr) -> new Object()));
+                                            command,
+                                            Optional.empty(),
+                                            new BaseCommandResponseResolver((ptr) -> new Object()));
                             result.get();
                         });
 
@@ -174,7 +183,8 @@ public class CommandManagerTest {
                         ExecutionException.class,
                         () -> {
                             CompletableFuture result =
-                                    service.submitNewCommand(command, new BaseCommandResponseResolver((ptr) -> null));
+                                    service.submitNewCommand(
+                                            command, Optional.empty(), new BaseCommandResponseResolver((ptr) -> null));
                             result.get();
                         });
 
@@ -216,7 +226,7 @@ public class CommandManagerTest {
         ArgumentCaptor<RedisRequest.Builder> captor =
                 ArgumentCaptor.forClass(RedisRequest.Builder.class);
 
-        service.submitNewCommand(command, new Route.Builder(routeType).build(), r -> null);
+        service.submitNewCommand(command, Optional.of(new Route.Builder(routeType).build()), r -> null);
         verify(channelHandler).write(captor.capture(), anyBoolean());
         var requestBuilder = captor.getValue();
 
@@ -249,7 +259,7 @@ public class CommandManagerTest {
                 ArgumentCaptor.forClass(RedisRequest.Builder.class);
 
         service.submitNewCommand(
-                command, new Route.Builder(routeType).setSlotId(42).build(), r -> null);
+                command, Optional.of(new Route.Builder(routeType).setSlotId(42).build()), r -> null);
         verify(channelHandler).write(captor.capture(), anyBoolean());
         var requestBuilder = captor.getValue();
 
@@ -283,7 +293,7 @@ public class CommandManagerTest {
                 ArgumentCaptor.forClass(RedisRequest.Builder.class);
 
         service.submitNewCommand(
-                command, new Route.Builder(routeType).setSlotKey("TEST").build(), r -> null);
+                command, Optional.of(new Route.Builder(routeType).setSlotKey("TEST").build()), r -> null);
         verify(channelHandler).write(captor.capture(), anyBoolean());
         var requestBuilder = captor.getValue();
 

--- a/java/client/src/test/java/glide/managers/CommandManagerTest.java
+++ b/java/client/src/test/java/glide/managers/CommandManagerTest.java
@@ -1,6 +1,8 @@
 package glide.managers;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,10 +10,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static response.ResponseOuterClass.RequestErrorType.UNRECOGNIZED;
 import static response.ResponseOuterClass.RequestErrorType.Unspecified;
 
+import glide.api.models.configuration.Route;
+import glide.api.models.configuration.Route.RouteType;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.ConnectionException;
 import glide.api.models.exceptions.ExecAbortException;
@@ -19,12 +24,17 @@ import glide.api.models.exceptions.RequestException;
 import glide.api.models.exceptions.TimeoutException;
 import glide.connectors.handlers.ChannelHandler;
 import glide.managers.models.Command;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import redis_request.RedisRequestOuterClass.RedisRequest;
+import redis_request.RedisRequestOuterClass.SimpleRoutes;
+import redis_request.RedisRequestOuterClass.SlotTypes;
 import response.ResponseOuterClass;
 import response.ResponseOuterClass.RequestError;
 import response.ResponseOuterClass.Response;
@@ -187,5 +197,106 @@ public class CommandManagerTest {
                 fail("Unexpected protobuf error type");
         }
         assertEquals(requestErrorType.toString(), executionException.getCause().getMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"ALL_NODES", "ALL_PRIMARIES", "RANDOM"})
+    public void prepare_request_with_simple_routes(RouteType routeType) {
+        CompletableFuture<Response> future = new CompletableFuture<>();
+        when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+        var protocSimpleRouteToClientSimpleRoute =
+                Map.of(
+                        SimpleRoutes.Random, RouteType.RANDOM,
+                        SimpleRoutes.AllNodes, RouteType.ALL_NODES,
+                        SimpleRoutes.AllPrimaries, RouteType.ALL_PRIMARIES);
+
+        ArgumentCaptor<RedisRequest.Builder> captor =
+                ArgumentCaptor.forClass(RedisRequest.Builder.class);
+
+        service.submitNewCommand(command, new Route.Builder(routeType).build(), r -> null);
+        verify(channelHandler).write(captor.capture(), anyBoolean());
+        var requestBuilder = captor.getValue();
+
+        assertAll(
+                () -> assertTrue(requestBuilder.hasRoute()),
+                () -> assertTrue(requestBuilder.getRoute().hasSimpleRoutes()),
+                () ->
+                        assertEquals(
+                                routeType,
+                                protocSimpleRouteToClientSimpleRoute.get(
+                                        requestBuilder.getRoute().getSimpleRoutes())),
+                () -> assertFalse(requestBuilder.getRoute().hasSlotIdRoute()),
+                () -> assertFalse(requestBuilder.getRoute().hasSlotKeyRoute()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"PRIMARY_SLOT_ID", "REPLICA_SLOT_ID"})
+    public void prepare_request_with_slot_id_routes(RouteType routeType) {
+        CompletableFuture<Response> future = new CompletableFuture<>();
+        when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+        var protocSlotTypeToClientSlotIdRoute =
+                Map.of(
+                        SlotTypes.Primary, RouteType.PRIMARY_SLOT_ID,
+                        SlotTypes.Replica, RouteType.REPLICA_SLOT_ID);
+
+        ArgumentCaptor<RedisRequest.Builder> captor =
+                ArgumentCaptor.forClass(RedisRequest.Builder.class);
+
+        service.submitNewCommand(
+                command, new Route.Builder(routeType).setSlotId(42).build(), r -> null);
+        verify(channelHandler).write(captor.capture(), anyBoolean());
+        var requestBuilder = captor.getValue();
+
+        assertAll(
+                () -> assertTrue(requestBuilder.hasRoute()),
+                () -> assertTrue(requestBuilder.getRoute().hasSlotIdRoute()),
+                () ->
+                        assertEquals(
+                                routeType,
+                                protocSlotTypeToClientSlotIdRoute.get(
+                                        requestBuilder.getRoute().getSlotIdRoute().getSlotType())),
+                () -> assertEquals(42, requestBuilder.getRoute().getSlotIdRoute().getSlotId()),
+                () -> assertFalse(requestBuilder.getRoute().hasSimpleRoutes()),
+                () -> assertFalse(requestBuilder.getRoute().hasSlotKeyRoute()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RouteType.class,
+            names = {"PRIMARY_SLOT_KEY", "REPLICA_SLOT_KEY"})
+    public void prepare_request_with_slot_key_routes(RouteType routeType) {
+        CompletableFuture<Response> future = new CompletableFuture<>();
+        when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+        var protocSlotTypeToClientSlotKeyRoute =
+                Map.of(
+                        SlotTypes.Primary, RouteType.PRIMARY_SLOT_KEY,
+                        SlotTypes.Replica, RouteType.REPLICA_SLOT_KEY);
+
+        ArgumentCaptor<RedisRequest.Builder> captor =
+                ArgumentCaptor.forClass(RedisRequest.Builder.class);
+
+        service.submitNewCommand(
+                command, new Route.Builder(routeType).setSlotKey("TEST").build(), r -> null);
+        verify(channelHandler).write(captor.capture(), anyBoolean());
+        var requestBuilder = captor.getValue();
+
+        assertAll(
+                () -> assertTrue(requestBuilder.hasRoute()),
+                () -> assertTrue(requestBuilder.getRoute().hasSlotKeyRoute()),
+                () ->
+                        assertEquals(
+                                routeType,
+                                protocSlotTypeToClientSlotKeyRoute.get(
+                                        requestBuilder.getRoute().getSlotKeyRoute().getSlotType())),
+                () -> assertEquals("TEST", requestBuilder.getRoute().getSlotKeyRoute().getSlotKey()),
+                () -> assertFalse(requestBuilder.getRoute().hasSimpleRoutes()),
+                () -> assertFalse(requestBuilder.getRoute().hasSlotIdRoute()));
     }
 }


### PR DESCRIPTION
Depends on:
- [x] #58 
- [x] #55

Features:
1. Cluster client
2. Cliend API to execute commands
3. Added option to execute every commands with routing settings
4. Added data conversion step: basic client converts data to string, cluster client converts to `RedisValue`, which is union to a string and a map

Use case:
```java
var client =
    ClusterClient.CreateClient(
            RedisClusterClientConfiguration.builder()
                .address(
                    NodeAddress.builder()
                        .host("cluster.redis.com")
                        .build())
                .useTLS(true)
                .build())
        .get();

var cmdRes1 = client.getCommandManager().get("956231").get();
// cmdRes1 contains a multi object => cmdRes1.hasMultiData() == true
//   <node1> : <value on node1>
//   <node2> : <value on node2>
//   <node3> : <value on node3>

// trying the same request to route to a single node:
var cmdRes2 = client.getCommandManager().get("956231", Route.builder().routeType(Route.RouteType.Random).build()).get();
// cmdRes2 contains a single object => cmdRes1.hasBulkData() == false
//   <value>

// another examples:
RedisValue res1 = clusterClient.customCommand(new String[] {"set", "kkk", "vvv"}).get();
RedisValue res2 = clusterClient.customCommand(
		new String[] {"get", "kkk"},
		Route.builder().routeType(Route.RouteType.AllNodes).build())
	.get();
RedisValue res3 = clusterClient.customCommand(
		new String[] {"get", "kkk"},
		Route.builder().routeType(Route.RouteType.Random).build())
	.get();
RedisValue res4 = clusterClient.customCommand(
		new String[] {"get", "kkk"},
		Route.builder().routeType(Route.RouteType.PrimarySlotId).slotId(42).build())
	.get();
```

Meanwhile a regular client has no option to set routes to a command.
![image](https://github.com/Bit-Quill/glide-for-redis/assets/88679692/ac449255-43fa-4c43-82d6-a70211e4bcc8)
![image](https://github.com/Bit-Quill/glide-for-redis/assets/88679692/1703fd5a-8622-4051-bedc-9df5ea0dd80f)
