### PR TITLE
Add IT framework

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -63,24 +63,30 @@ jobs:
               uses: ./.github/workflows/install-redis
               with:
                   redis-version: ${{ matrix.redis }}
+                  
+            - name: Install tree
+              if: ${{ matrix.os == 'macos-latest' }}
+              run: brew install tree
 
-            - name: Build rust part
-              working-directory: java
-              run: cargo build --release
-
-            - name: Build java part
+            - name: Build java client
               working-directory: java
               run: ./gradlew --continue build
+              
+            - name: test
+              run: |
+                pwd
+                tree utils/clusters/
 
             - name: Upload test reports
               if: always()
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-${{ matrix.java }}
+                  name: test-reports-java-${{ matrix.java }}-redis-${{ matrix.redis }}-${{ matrix.os }}
                   path: |
                       java/client/build/reports/**
                       java/integTest/build/reports/**
+                      utils/clusters/**
 
     build-amazonlinux-latest:
         if: github.repository_owner == 'aws'

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -63,19 +63,10 @@ jobs:
               uses: ./.github/workflows/install-redis
               with:
                   redis-version: ${{ matrix.redis }}
-                  
-            - name: Install tree
-              if: ${{ matrix.os == 'macos-latest' }}
-              run: brew install tree
 
             - name: Build java client
               working-directory: java
               run: ./gradlew --continue build
-              
-            - name: test
-              run: |
-                pwd
-                tree utils/clusters/
 
             - name: Upload test reports
               if: always()

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -110,7 +110,7 @@ tasks.register('buildAll') {
     finalizedBy 'build'
 }
 
-compileJava.dependsOn('protobuf', 'buildRustRelease')
+compileJava.dependsOn('protobuf')
 clean.dependsOn('cleanProtobuf', 'cleanRust')
 test.dependsOn('buildRust')
 testFfi.dependsOn('buildRust')
@@ -127,4 +127,3 @@ tasks.withType(Test) {
     }
     jvmArgs "-Djava.library.path=${projectDir}/../target/debug"
 }
-

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 tasks.register('stopAllAfterTests', Exec) {
     workingDir "${project.rootDir}/../utils"
     commandLine 'python3', 'cluster_manager.py', 'stop', '--prefix', 'redis-cluster', '--keep-folder'
-    ignoreExitValue true
 }
 
 // We need to call for stop before and after the test, but gradle doesn't support executing a task
@@ -31,7 +30,7 @@ tasks.register('stopAllAfterTests', Exec) {
 tasks.register('stopAllBeforeTests', Exec) {
     workingDir "${project.rootDir}/../utils"
     commandLine 'python3', 'cluster_manager.py', 'stop', '--prefix', 'redis-cluster'
-    ignoreExitValue true
+    ignoreExitValue true // ignore fail if servers are stopped before
 }
 
 // delete dirs if stop failed due to https://github.com/aws/glide-for-redis/issues/849
@@ -51,9 +50,10 @@ tasks.register('startStandalone', Exec) {
 
 test.dependsOn 'stopAllBeforeTests'
 stopAllBeforeTests.finalizedBy 'clearDirs'
-clearDirs.dependsOn 'startStandalone'
-clearDirs.dependsOn 'startCluster'
+clearDirs.finalizedBy 'startStandalone'
+clearDirs.finalizedBy 'startCluster'
 test.finalizedBy 'stopAllAfterTests'
+test.dependsOn ':client:buildRust'
 
 tasks.withType(Test) {
     systemProperty 'test.redis.standalone.port', '6380'

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -1,0 +1,68 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // client
+    implementation project(':client')
+
+    // lombok
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+    // junit
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.12.4'
+}
+
+tasks.register('stopAllAfterTests', Exec) {
+    workingDir "${project.rootDir}/../utils"
+    commandLine 'python3', 'cluster_manager.py', 'stop', '--prefix', 'redis-cluster', '--keep-folder'
+    ignoreExitValue true
+}
+
+// We need to call for stop before and after the test, but gradle doesn't support executing a task
+// twice. So there are two identical tasks with different names.
+// We need to call for stop in case if previous test run was interrupted/crashed and didn't stop.
+tasks.register('stopAllBeforeTests', Exec) {
+    workingDir "${project.rootDir}/../utils"
+    commandLine 'python3', 'cluster_manager.py', 'stop', '--prefix', 'redis-cluster'
+    ignoreExitValue true
+}
+
+// delete dirs if stop failed due to https://github.com/aws/glide-for-redis/issues/849
+tasks.register('clearDirs', Delete) {
+    delete "${project.rootDir}/../utils/clusters"
+}
+
+tasks.register('startCluster', Exec) {
+    workingDir "${project.rootDir}/../utils"
+    commandLine 'python3', 'cluster_manager.py', 'start', '--cluster-mode', '-p', '7000', '7001', '7002', '7003', '7004', '7005'
+}
+
+tasks.register('startStandalone', Exec) {
+    workingDir "${project.rootDir}/../utils"
+    commandLine 'python3', 'cluster_manager.py', 'start', '-p', '6380', '-r', '0'
+}
+
+test.dependsOn 'stopAllBeforeTests'
+stopAllBeforeTests.finalizedBy 'clearDirs'
+clearDirs.dependsOn 'startStandalone'
+clearDirs.dependsOn 'startCluster'
+test.finalizedBy 'stopAllAfterTests'
+
+tasks.withType(Test) {
+    systemProperty 'test.redis.standalone.port', '6380'
+    systemProperty 'test.redis.cluster.port', '7000'
+
+    testLogging {
+        exceptionFormat "full"
+        events "started", "skipped", "passed", "failed"
+        showStandardStreams true
+    }
+    jvmArgs "-Djava.library.path=${project.rootDir}/target/debug"
+}

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -53,7 +53,7 @@ stopAllBeforeTests.finalizedBy 'clearDirs'
 clearDirs.finalizedBy 'startStandalone'
 clearDirs.finalizedBy 'startCluster'
 test.finalizedBy 'stopAllAfterTests'
-test.dependsOn ':client:buildRust'
+test.dependsOn ':client:buildRustRelease'
 
 tasks.withType(Test) {
     systemProperty 'test.redis.standalone.port', '6380'
@@ -64,5 +64,5 @@ tasks.withType(Test) {
         events "started", "skipped", "passed", "failed"
         showStandardStreams true
     }
-    jvmArgs "-Djava.library.path=${project.rootDir}/target/debug"
+    jvmArgs "-Djava.library.path=${project.rootDir}/target/release"
 }

--- a/java/integTest/src/test/java/glide/CommandTests.java
+++ b/java/integTest/src/test/java/glide/CommandTests.java
@@ -17,11 +17,11 @@ public class CommandTests {
     @SneakyThrows
     public static void init() {
         regularClient =
-            RedisClient.CreateClient(
-                    RedisClientConfiguration.builder()
-                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
-                        .build())
-                .get(10, TimeUnit.SECONDS);
+                RedisClient.CreateClient(
+                                RedisClientConfiguration.builder()
+                                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
+                                        .build())
+                        .get(10, TimeUnit.SECONDS);
     }
 
     @AfterAll

--- a/java/integTest/src/test/java/glide/CommandTests.java
+++ b/java/integTest/src/test/java/glide/CommandTests.java
@@ -1,0 +1,24 @@
+package glide;
+
+import glide.api.RedisClient;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RedisClientConfiguration;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+public class CommandTests {
+
+    @Test
+    @SneakyThrows
+    public void custom_command_info() {
+        var regularClient =
+                RedisClient.CreateClient(
+                                RedisClientConfiguration.builder()
+                                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
+                                        .build())
+                        .get(10, TimeUnit.SECONDS);
+        regularClient.customCommand(new String[] {"info"}).get();
+        regularClient.close();
+    }
+}

--- a/java/integTest/src/test/java/glide/CommandTests.java
+++ b/java/integTest/src/test/java/glide/CommandTests.java
@@ -5,20 +5,34 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class CommandTests {
 
+    private static RedisClient regularClient = null;
+
+    @BeforeAll
+    @SneakyThrows
+    public static void init() {
+        regularClient =
+            RedisClient.CreateClient(
+                    RedisClientConfiguration.builder()
+                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
+                        .build())
+                .get(10, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    @SneakyThrows
+    public static void deinit() {
+        regularClient.close();
+    }
+
     @Test
     @SneakyThrows
     public void custom_command_info() {
-        var regularClient =
-                RedisClient.CreateClient(
-                                RedisClientConfiguration.builder()
-                                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
-                                        .build())
-                        .get(10, TimeUnit.SECONDS);
-        regularClient.customCommand(new String[] {"info"}).get();
-        regularClient.close();
+        regularClient.customCommand(new String[] {"info"}).get(10, TimeUnit.SECONDS);
     }
 }

--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -1,0 +1,25 @@
+package glide;
+
+import glide.api.RedisClient;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RedisClientConfiguration;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+public class ConnectionTests {
+
+    @Test
+    @SneakyThrows
+    public void basic_client() {
+        var regularClient =
+                RedisClient.CreateClient(
+                                RedisClientConfiguration.builder()
+                                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
+                                        .build())
+                        .get(10, TimeUnit.SECONDS);
+        regularClient.close();
+    }
+
+    // TODO cluster client once implemented
+}

--- a/java/integTest/src/test/java/glide/TestConfiguration.java
+++ b/java/integTest/src/test/java/glide/TestConfiguration.java
@@ -1,0 +1,9 @@
+package glide;
+
+public class TestConfiguration {
+    // All redis servers are hosted on localhost
+    public static final int STANDALONE_PORT =
+            Integer.parseInt(System.getProperty("test.redis.standalone.port"));
+    public static final int CLUSTER_PORT =
+            Integer.parseInt(System.getProperty("test.redis.cluster.port"));
+}

--- a/java/integTest/src/test/resources/junit-platform.properties
+++ b/java/integTest/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.displayname.generator.default = \
+    org.junit.jupiter.api.DisplayNameGenerator$ReplaceUnderscores

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import argparse
 import logging
 import os
@@ -258,7 +260,7 @@ def create_cluster_folder(path: str, prefix: str) -> str:
         str: The full path of the cluster folder
     """
     time = datetime.now(timezone.utc)
-    time_str = time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    time_str = time.strftime("%Y-%m-%dT%H-%M-%SZ")
     cluster_folder = f"{path}/{prefix}-{time_str}-{get_random_string(6)}"
     logging.debug(f"## Creating cluster folder in {cluster_folder}")
     Path(cluster_folder).mkdir(exist_ok=True)


### PR DESCRIPTION
Based on #54/https://github.com/aws/glide-for-redis/pull/796

This starts redis in standalone mode on port 6380 in CI and a cluster on ports 7000-7006.
To connect to standalone use:
```java
    var client =
        RedisClient.CreateClient(
                RedisClientConfiguration.builder()
                    .address(
                        NodeAddress.builder()
                            .port(TestConfiguration.STANDALONE_PORT)
                            .build())
                    .build())
            .get(10, TimeUnit.SECONDS);
```
To connect to cluster use:
```java
    var clusterClient =
        ClusterClient.CreateClient(
                RedisClusterClientConfiguration.builder()
                    .address(
                        NodeAddress.builder()
                            .port(TestConfiguration.CLUSTER_PORT)
                            .build())
                    .requestTimeout(3000)
                    .build())
            .get(10, TimeUnit.SECONDS);
```

**NOTE** don't use `Future::get` without specifying a timeout, because it hangs IT/CI on an error!

Test can be started by
```
./gradlew :integTest:test
```
The test report is written to 
```
integTest/build/reports/tests/test/index.html
```
Redis server logs are stored in
```
<repo root>/utils/clusters
```
until next test start


To start redis standalone instance IT uses
```
python3 <repo root>/utils/cluster_manager.py start -p 6380 -r 0
```
To start redis cluster
```
python3 <repo root>/utils/cluster_manager.py start --cluster-mode -p 8000 8001 8002 8003 8004 8005
```
To stop all
```
python3 <repo root>/utils/cluster_manager.py stop --prefix redis-cluster
```