### PR TITLE
Java client: update error handling

### DIFF
--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -110,7 +110,7 @@ tasks.register('buildAll') {
     finalizedBy 'build'
 }
 
-compileJava.dependsOn('protobuf', 'buildRustRelease')
+compileJava.dependsOn('protobuf')
 clean.dependsOn('cleanProtobuf', 'cleanRust')
 test.dependsOn('buildRust')
 testFfi.dependsOn('buildRust')
@@ -127,4 +127,3 @@ tasks.withType(Test) {
     }
     jvmArgs "-Djava.library.path=${projectDir}/../target/debug"
 }
-

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
-import response.ResponseOuterClass;
+import response.ResponseOuterClass.RequestError;
 import response.ResponseOuterClass.Response;
 
 /** Holder for resources required to dispatch responses and used by {@link ReadHandler}. */
@@ -85,7 +85,7 @@ public class CallbackDispatcher {
         freeRequestIds.add(callbackId);
         if (future != null) {
             if (response.hasRequestError()) {
-                ResponseOuterClass.RequestError error = response.getRequestError();
+                RequestError error = response.getRequestError();
                 String msg = error.getMessage();
                 switch (error.getType()) {
                     case Unspecified:

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -1,11 +1,17 @@
 package glide.connectors.handlers;
 
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.ExecAbortException;
+import glide.api.models.exceptions.RequestException;
+import glide.api.models.exceptions.TimeoutException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
+import response.ResponseOuterClass;
 import response.ResponseOuterClass.Response;
 
 /** Holder for resources required to dispatch responses and used by {@link ReadHandler}. */
@@ -13,7 +19,7 @@ import response.ResponseOuterClass.Response;
 public class CallbackDispatcher {
 
     /** Unique request ID (callback ID). Thread-safe and overflow-safe. */
-    private final AtomicInteger nextAvailableRequestId = new AtomicInteger(0);
+    protected final AtomicInteger nextAvailableRequestId = new AtomicInteger(0);
 
     /**
      * Storage of Futures to handle responses. Map key is callback id, which starts from 0. The value
@@ -23,7 +29,7 @@ public class CallbackDispatcher {
      * Negative Java values would be shown as positive on Rust side. There is no data loss, because
      * callback ID remains unique.
      */
-    private final ConcurrentHashMap<Integer, CompletableFuture<Response>> responses =
+    protected final ConcurrentHashMap<Integer, CompletableFuture<Response>> responses =
             new ConcurrentHashMap<>();
 
     /**
@@ -32,7 +38,7 @@ public class CallbackDispatcher {
      */
     // TODO: Optimize to avoid growing up to 2e32 (16 Gb)
     // https://github.com/aws/glide-for-redis/issues/704
-    private final ConcurrentLinkedQueue<Integer> freeRequestIds = new ConcurrentLinkedQueue<>();
+    protected final ConcurrentLinkedQueue<Integer> freeRequestIds = new ConcurrentLinkedQueue<>();
 
     /**
      * Register a new request to be sent. Once response received, the given future completes with it.
@@ -58,21 +64,54 @@ public class CallbackDispatcher {
     }
 
     /**
-     * Complete the corresponding client promise and free resources.
+     * Complete the corresponding client promise, handle error and free resources.
      *
      * @param response A response received
      */
     public void completeRequest(Response response) {
+        if (response.hasClosingError()) {
+            // According to https://github.com/aws/glide-for-redis/issues/851
+            // a response with a closing error may arrive with any/random callback ID (usually -1)
+            // CommandManager and ConnectionManager would close the UDS channel on ClosingException
+            responses
+                    .values()
+                    .forEach(f -> f.completeExceptionally(new ClosingException(response.getClosingError())));
+            responses.clear();
+        }
         // Complete and return the response at callbackId
         // free up the callback ID in the freeRequestIds list
         int callbackId = response.getCallbackIdx();
         CompletableFuture<Response> future = responses.remove(callbackId);
         freeRequestIds.add(callbackId);
         if (future != null) {
+            if (response.hasRequestError()) {
+                ResponseOuterClass.RequestError error = response.getRequestError();
+                String msg = error.getMessage();
+                switch (error.getType()) {
+                    case Unspecified:
+                        // Unspecified error on Redis service-side
+                        future.completeExceptionally(new RequestException(msg));
+                    case ExecAbort:
+                        // Transactional error on Redis service-side
+                        future.completeExceptionally(new ExecAbortException(msg));
+                    case Timeout:
+                        // Timeout from Glide to Redis service
+                        future.completeExceptionally(new TimeoutException(msg));
+                    case Disconnect:
+                        // Connection problem between Glide and Redis
+                        future.completeExceptionally(new ConnectionException(msg));
+                    default:
+                        // Request or command error from Redis
+                        future.completeExceptionally(new RequestException(msg));
+                }
+            }
             future.completeAsync(() -> response);
         } else {
             // TODO: log an error.
             // probably a response was received after shutdown or `registerRequest` call was missing
+
+            System.err.printf(
+                    "Received a response for not registered callback id %d%n%s%n", callbackId, response);
         }
     }
 

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -77,13 +77,14 @@ public class CallbackDispatcher {
                     .values()
                     .forEach(f -> f.completeExceptionally(new ClosingException(response.getClosingError())));
             responses.clear();
+            return;
         }
         // Complete and return the response at callbackId
         // free up the callback ID in the freeRequestIds list
         int callbackId = response.getCallbackIdx();
         CompletableFuture<Response> future = responses.remove(callbackId);
-        freeRequestIds.add(callbackId);
         if (future != null) {
+            freeRequestIds.add(callbackId);
             if (response.hasRequestError()) {
                 RequestError error = response.getRequestError();
                 String msg = error.getMessage();
@@ -111,7 +112,8 @@ public class CallbackDispatcher {
             // probably a response was received after shutdown or `registerRequest` call was missing
 
             System.err.printf(
-                    "Received a response for not registered callback id %d%n%s%n", callbackId, response);
+                    "Received a response for not registered callback id %d, request error = %s%n",
+                    callbackId, response.getRequestError());
         }
     }
 

--- a/java/client/src/main/java/glide/connectors/handlers/ChannelHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ChannelHandler.java
@@ -24,8 +24,8 @@ public class ChannelHandler {
 
     private static final String THREAD_POOL_NAME = "glide-channel";
 
-    private final Channel channel;
-    private final CallbackDispatcher callbackDispatcher;
+    protected final Channel channel;
+    protected final CallbackDispatcher callbackDispatcher;
 
     /** Open a new channel for a new client. */
     public ChannelHandler(CallbackDispatcher callbackDispatcher, String socketPath)
@@ -41,11 +41,11 @@ public class ChannelHandler {
     /**
      * Open a new channel for a new client and running it on the provided EventLoopGroup
      *
-     * @param eventLoopGroup - ELG to run handler on
-     * @param domainSocketChannelClass - socket channel class for Handler
-     * @param channelInitializer - UnixChannel initializer
-     * @param domainSocketAddress - address to connect
-     * @param callbackDispatcher - dispatcher to handle callbacks
+     * @param eventLoopGroup ELG to run handler on
+     * @param domainSocketChannelClass Socket channel class for Handler
+     * @param channelInitializer UnixChannel initializer
+     * @param domainSocketAddress Address to connect
+     * @param callbackDispatcher Dispatcher to handle callbacks
      */
     public ChannelHandler(
             EventLoopGroup eventLoopGroup,

--- a/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
+++ b/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
@@ -14,13 +14,12 @@ public class BaseCommandResponseResolver
     private RedisExceptionCheckedFunction<Long, Object> respPointerResolver;
 
     /**
-     * Extracts value from the RESP pointer. <br>
-     * Throws errors when the response is unsuccessful.
+     * Extracts value from the RESP pointer.
      *
-     * @return A generic Object with the Response | null if the response is empty
+     * @return A generic Object with the Response or null if the response is empty
      */
     public Object apply(Response response) throws RedisException {
-        // Note: errors are already handled before
+        // Note: errors are already handled before in CallbackDispatcher
         if (response.hasConstantResponse()) {
             // Return "OK"
             return response.getConstantResponse().toString();

--- a/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
+++ b/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
@@ -20,6 +20,9 @@ public class BaseCommandResponseResolver
      */
     public Object apply(Response response) throws RedisException {
         // Note: errors are already handled before in CallbackDispatcher
+        assert !response.hasClosingError() : "Unhandled response closing error";
+        assert !response.hasRequestError() : "Unhandled response request error";
+
         if (response.hasConstantResponse()) {
             // Return "OK"
             return response.getConstantResponse().toString();

--- a/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
+++ b/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
@@ -1,13 +1,7 @@
 package glide.managers;
 
-import glide.api.models.exceptions.ClosingException;
-import glide.api.models.exceptions.ConnectionException;
-import glide.api.models.exceptions.ExecAbortException;
 import glide.api.models.exceptions.RedisException;
-import glide.api.models.exceptions.RequestException;
-import glide.api.models.exceptions.TimeoutException;
 import lombok.AllArgsConstructor;
-import response.ResponseOuterClass.RequestError;
 import response.ResponseOuterClass.Response;
 
 /**
@@ -26,34 +20,7 @@ public class BaseCommandResponseResolver
      * @return A generic Object with the Response | null if the response is empty
      */
     public Object apply(Response response) throws RedisException {
-        if (response.hasRequestError()) {
-            RequestError error = response.getRequestError();
-            String msg = error.getMessage();
-            switch (error.getType()) {
-                case Unspecified:
-                    // Unspecified error on Redis service-side
-                    throw new RequestException(msg);
-                case ExecAbort:
-                    // Transactional error on Redis service-side
-                    throw new ExecAbortException(msg);
-                case Timeout:
-                    // Timeout from Glide to Redis service
-                    throw new TimeoutException(msg);
-                case Disconnect:
-                    // Connection problem between Glide and Redis
-                    throw new ConnectionException(msg);
-                default:
-                    // Request or command error from Redis
-                    throw new RequestException(msg);
-            }
-        }
-        if (response.hasClosingError()) {
-            // A closing error is thrown when Rust-core is not connected to Redis
-            // We want to close shop and throw a ClosingException
-            // TODO: close the channel on a closing error
-            // channel.close();
-            throw new ClosingException(response.getClosingError());
-        }
+        // Note: errors are already handled before
         if (response.hasConstantResponse()) {
             // Return "OK"
             return response.getConstantResponse().toString();

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -1,5 +1,6 @@
 package glide.managers;
 
+import glide.api.models.exceptions.ClosingException;
 import glide.connectors.handlers.ChannelHandler;
 import glide.managers.models.Command;
 import java.util.concurrent.CompletableFuture;
@@ -31,7 +32,24 @@ public class CommandManager {
         // when complete, convert the response to our expected type T using the given responseHandler
         return channel
                 .write(prepareRedisRequest(command.getRequestType(), command.getArguments()), true)
+                .exceptionally(this::exceptionHandler)
                 .thenApplyAsync(response -> responseHandler.apply(response));
+    }
+
+    /**
+     * Exception handler for future pipeline.
+     *
+     * @param e An exception thrown in the pipeline before
+     * @return Nothing, it rethrows the exception
+     */
+    private Response exceptionHandler(Throwable e) {
+        if (e instanceof ClosingException) {
+            channel.close();
+        }
+        if (e instanceof RuntimeException) {
+            throw (RuntimeException) e;
+        }
+        throw new RuntimeException(e);
     }
 
     /**

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -47,6 +47,7 @@ public class CommandManager {
             channel.close();
         }
         if (e instanceof RuntimeException) {
+            // RedisException also goes here
             throw (RuntimeException) e;
         }
         throw new RuntimeException(e);

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -12,10 +12,8 @@ import glide.api.models.configuration.RedisClusterClientConfiguration;
 import glide.api.models.exceptions.ClosingException;
 import glide.connectors.handlers.ChannelHandler;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import lombok.RequiredArgsConstructor;
-import response.ResponseOuterClass.RequestError;
 import response.ResponseOuterClass.Response;
 
 /**

--- a/java/client/src/test/java/glide/ExceptionHandlingTests.java
+++ b/java/client/src/test/java/glide/ExceptionHandlingTests.java
@@ -1,0 +1,256 @@
+package glide;
+
+import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static response.ResponseOuterClass.RequestErrorType.Disconnect;
+import static response.ResponseOuterClass.RequestErrorType.ExecAbort;
+import static response.ResponseOuterClass.RequestErrorType.Timeout;
+import static response.ResponseOuterClass.RequestErrorType.Unspecified;
+
+import connection_request.ConnectionRequestOuterClass;
+import glide.api.models.configuration.RedisClientConfiguration;
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.ExecAbortException;
+import glide.api.models.exceptions.RequestException;
+import glide.api.models.exceptions.TimeoutException;
+import glide.connectors.handlers.CallbackDispatcher;
+import glide.connectors.handlers.ChannelHandler;
+import glide.managers.CommandManager;
+import glide.managers.ConnectionManager;
+import glide.managers.models.Command;
+import glide.managers.models.Command.RequestType;
+import io.netty.channel.ChannelFuture;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import redis_request.RedisRequestOuterClass.RedisRequest;
+import response.ResponseOuterClass.RequestError;
+import response.ResponseOuterClass.Response;
+
+// ./gradlew :client:test --tests ExceptionHandlingTests  --debug-jvm
+public class ExceptionHandlingTests {
+
+    /**
+     * This test shows how exception handling works in the middle of future pipeline The client has
+     * similar stuff, but it rethrows an exception.
+     */
+    @SneakyThrows
+    @Test
+    public void verify_future_pipeline_abortion() {
+        var future = new CompletableFuture<Boolean>();
+        var future2 = future.exceptionally(e -> false).thenApplyAsync(r -> r ? 42 : 100500);
+
+        future.completeExceptionally(new IllegalArgumentException());
+
+        assertEquals(100500, future2.get());
+    }
+
+    @Test
+    @SneakyThrows
+    public void channel_is_closed_when_failed_to_connect() {
+        // init stuff like client does
+        var callbackDispatcher = new TestCallbackDispatcher(new ClosingException("TEST"));
+        var channelHandler = new TestChannelHandler(callbackDispatcher);
+        var connectionManager = new ConnectionManager(channelHandler);
+        var future = connectionManager.connectToRedis(createDummyConfig());
+
+        callbackDispatcher.completeRequest(null);
+        var exception = assertThrows(ExecutionException.class, future::get);
+        // a ClosingException thrown from CallbackDispatcher::completeRequest and then
+        // rethrown by ConnectionManager::exceptionHandler
+        assertTrue(exception.getCause() instanceof ClosingException);
+        assertTrue(channelHandler.wasClosed);
+    }
+
+    @Test
+    @SneakyThrows
+    public void channel_is_closed_when_disconnected_on_command() {
+        var callbackDispatcher = new TestCallbackDispatcher(new ClosingException("TEST"));
+        var channelHandler = new TestChannelHandler(callbackDispatcher);
+        var commandManager = new CommandManager(channelHandler);
+
+        var future = commandManager.submitNewCommand(createDummyCommand(), r -> null);
+        callbackDispatcher.completeRequest(null);
+        var exception = assertThrows(ExecutionException.class, future::get);
+        // a ClosingException thrown from CallbackDispatcher::completeRequest and then
+        // rethrown by CommandManager::exceptionHandler
+        assertTrue(exception.getCause() instanceof ClosingException);
+        // check the channel
+        assertTrue(channelHandler.wasClosed);
+    }
+
+    @Test
+    @SneakyThrows
+    public void channel_is_not_closed_when_error_was_in_command_pipeline() {
+        var callbackDispatcher = new TestCallbackDispatcher(new RequestException("TEST"));
+        var channelHandler = new TestChannelHandler(callbackDispatcher);
+        var commandManager = new CommandManager(channelHandler);
+
+        var future = commandManager.submitNewCommand(createDummyCommand(), r -> null);
+        callbackDispatcher.completeRequest(null);
+        var exception = assertThrows(ExecutionException.class, future::get);
+        // a RequestException thrown from CallbackDispatcher::completeRequest and then
+        // rethrown by CommandManager::exceptionHandler
+        assertTrue(exception.getCause() instanceof RequestException);
+        // check the channel
+        assertFalse(channelHandler.wasClosed);
+    }
+
+    @Test
+    @SneakyThrows
+    public void command_manager_rethrows_non_RedisException_too() {
+        var callbackDispatcher = new TestCallbackDispatcher(new IOException("TEST"));
+        var channelHandler = new TestChannelHandler(callbackDispatcher);
+        var commandManager = new CommandManager(channelHandler);
+
+        var future = commandManager.submitNewCommand(createDummyCommand(), r -> null);
+        callbackDispatcher.completeRequest(null);
+        var exception = assertThrows(ExecutionException.class, future::get);
+        // a IOException thrown from CallbackDispatcher::completeRequest and then wrapped
+        // by a RuntimeException and rethrown by CommandManager::exceptionHandler
+        assertTrue(exception.getCause() instanceof RuntimeException);
+        assertTrue(exception.getCause().getCause() instanceof IOException);
+        // check the channel
+        assertFalse(channelHandler.wasClosed);
+    }
+
+    @Test
+    @SneakyThrows
+    public void connection_manager_rethrows_non_RedisException_too() {
+        var callbackDispatcher = new TestCallbackDispatcher(new IOException("TEST"));
+        var channelHandler = new TestChannelHandler(callbackDispatcher);
+        var connectionManager = new ConnectionManager(channelHandler);
+
+        var future = connectionManager.connectToRedis(createDummyConfig());
+        callbackDispatcher.completeRequest(null);
+
+        var exception = assertThrows(ExecutionException.class, future::get);
+        // a IOException thrown from CallbackDispatcher::completeRequest and then wrapped
+        // by a RuntimeException and rethrown by ConnectionManager::exceptionHandler
+        assertTrue(exception.getCause() instanceof RuntimeException);
+        assertTrue(exception.getCause().getCause() instanceof IOException);
+        // check the channel
+        assertTrue(channelHandler.wasClosed);
+    }
+
+    @Test
+    @SneakyThrows
+    public void callback_dispatcher_handles_response_with_closing_error() {
+        var callbackDispatcher = new CallbackDispatcher();
+        var channelHandler = new TestChannelHandler(callbackDispatcher);
+        var connectionManager = new ConnectionManager(channelHandler);
+
+        var future1 = connectionManager.connectToRedis(createDummyConfig());
+        var future2 = connectionManager.connectToRedis(createDummyConfig());
+        var response = Response.newBuilder().setCallbackIdx(42).setClosingError("TEST").build();
+        callbackDispatcher.completeRequest(response);
+
+        var exception = assertThrows(ExecutionException.class, future1::get);
+        // a ClosingException thrown from CallbackDispatcher::completeRequest and then
+        // rethrown by CommandManager::exceptionHandler
+        assertTrue(exception.getCause() instanceof ClosingException);
+        // check the channel
+        assertTrue(channelHandler.wasClosed);
+
+        // all pending requests should be aborted once ClosingError received in callback dispatcher
+        exception = assertThrows(ExecutionException.class, future2::get);
+        // or could be cancelled in CallbackDispatcher::shutdownGracefully
+        // cancellation overwrites previous status, so we may not get ClosingException due to a race
+        assertTrue(
+                exception.getCause() instanceof ClosingException
+                        || exception.getCause() instanceof CancellationException);
+    }
+
+    @Test
+    @SneakyThrows
+    public void callback_dispatcher_handles_response_with_request_error() {
+        var callbackDispatcher = new CallbackDispatcher();
+        var channelHandler = new TestChannelHandler(callbackDispatcher);
+        var commandManager = new CommandManager(channelHandler);
+
+        var protobufErrorsToJavaClientErrors =
+                Map.of(
+                        Unspecified, RequestException.class,
+                        ExecAbort, ExecAbortException.class,
+                        Timeout, TimeoutException.class,
+                        Disconnect, ConnectionException.class);
+        // can't test default branch in switch-case
+
+        for (var errorType : protobufErrorsToJavaClientErrors.entrySet()) {
+            var future = commandManager.submitNewCommand(createDummyCommand(), r -> null);
+            var response =
+                    Response.newBuilder()
+                            .setCallbackIdx(0)
+                            .setRequestError(
+                                    RequestError.newBuilder().setType(errorType.getKey()).setMessage("TEST"))
+                            .build();
+            callbackDispatcher.completeRequest(response);
+
+            var exception = assertThrows(ExecutionException.class, future::get);
+            // a ClosingException thrown from CallbackDispatcher::completeRequest and then
+            // rethrown by CommandManager::exceptionHandler
+            assertEquals(errorType.getValue(), exception.getCause().getClass());
+            assertEquals("TEST", exception.getCause().getMessage());
+            // check the channel
+            assertFalse(channelHandler.wasClosed);
+        }
+    }
+
+    /** Create a config which causes connection failure. */
+    private static RedisClientConfiguration createDummyConfig() {
+        return RedisClientConfiguration.builder().build();
+    }
+
+    private static Command createDummyCommand() {
+        return Command.builder().requestType(RequestType.CUSTOM_COMMAND).build();
+    }
+
+    /** Test ChannelHandler extension which allows to validate whether the channel was closed. */
+    private static class TestChannelHandler extends ChannelHandler {
+
+        public TestChannelHandler(CallbackDispatcher callbackDispatcher) throws InterruptedException {
+            super(callbackDispatcher, getSocket());
+        }
+
+        public boolean wasClosed = false;
+
+        @Override
+        public ChannelFuture close() {
+            wasClosed = true;
+            return super.close();
+        }
+
+        @Override
+        public CompletableFuture<Response> write(RedisRequest.Builder request, boolean flush) {
+            var commandId = callbackDispatcher.registerRequest();
+            return commandId.getValue();
+        }
+
+        @Override
+        public CompletableFuture<Response> connect(
+                ConnectionRequestOuterClass.ConnectionRequest request) {
+            return callbackDispatcher.registerConnection();
+        }
+    }
+
+    /** Test ChannelHandler extension which aborts futures for all commands. */
+    @RequiredArgsConstructor
+    private static class TestCallbackDispatcher extends CallbackDispatcher {
+
+        public final Throwable exceptionToThrow;
+
+        @Override
+        public void completeRequest(Response response) {
+            responses.values().forEach(future -> future.completeExceptionally(exceptionToThrow));
+        }
+    }
+}

--- a/java/client/src/test/java/glide/ExceptionHandlingTests.java
+++ b/java/client/src/test/java/glide/ExceptionHandlingTests.java
@@ -19,6 +19,7 @@ import glide.api.models.exceptions.RequestException;
 import glide.api.models.exceptions.TimeoutException;
 import glide.connectors.handlers.CallbackDispatcher;
 import glide.connectors.handlers.ChannelHandler;
+import glide.managers.BaseCommandResponseResolver;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
 import glide.managers.models.Command;
@@ -203,6 +204,22 @@ public class ExceptionHandlingTests {
             // check the channel
             assertFalse(channelHandler.wasClosed);
         }
+    }
+
+    @Test
+    public void response_resolver_does_not_expect_errors() {
+        var resolver = new BaseCommandResponseResolver(null);
+
+        var response1 =
+                Response.newBuilder()
+                        .setRequestError(RequestError.newBuilder().setType(ExecAbort).setMessage("TEST"))
+                        .build();
+        var exception = assertThrows(Throwable.class, () -> resolver.apply(response1));
+        assertEquals("Unhandled response request error", exception.getMessage());
+
+        var response2 = Response.newBuilder().setClosingError("TEST").build();
+        exception = assertThrows(Throwable.class, () -> resolver.apply(response2));
+        assertEquals("Unhandled response closing error", exception.getMessage());
     }
 
     /** Create a config which causes connection failure. */

--- a/java/client/src/test/java/glide/api/RedisClientCreateTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientCreateTest.java
@@ -50,7 +50,7 @@ public class RedisClientCreateTest {
 
     @Test
     @SneakyThrows
-    public void createClient_withConfig_successfullyReturnsRedisClient() {
+    public void createClient_with_config_successfully_returns_RedisClient() {
 
         // setup
         CompletableFuture<Void> connectToRedisFuture = new CompletableFuture<>();
@@ -71,7 +71,7 @@ public class RedisClientCreateTest {
 
     @SneakyThrows
     @Test
-    public void createClient_errorOnConnectionThrowsExecutionException() {
+    public void createClient_error_on_connection_throws_ExecutionException() {
         // setup
         CompletableFuture<Void> connectToRedisFuture = new CompletableFuture<>();
         ClosingException exception = new ClosingException("disconnected");
@@ -84,8 +84,7 @@ public class RedisClientCreateTest {
         // exercise
         CompletableFuture<RedisClient> result = CreateClient(config);
 
-        ExecutionException executionException =
-                assertThrows(ExecutionException.class, () -> result.get());
+        ExecutionException executionException = assertThrows(ExecutionException.class, result::get);
 
         // verify
         assertEquals(exception, executionException.getCause());

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -13,10 +13,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import connection_request.ConnectionRequestOuterClass;
-import connection_request.ConnectionRequestOuterClass.TlsMode;
 import connection_request.ConnectionRequestOuterClass.AuthenticationInfo;
 import connection_request.ConnectionRequestOuterClass.ConnectionRequest;
 import connection_request.ConnectionRequestOuterClass.ConnectionRetryStrategy;
+import connection_request.ConnectionRequestOuterClass.TlsMode;
 import glide.api.models.configuration.BackoffStrategy;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.ReadFrom;
@@ -31,8 +31,6 @@ import java.util.concurrent.ExecutionException;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import response.ResponseOuterClass.RequestError;
-import response.ResponseOuterClass.RequestErrorType;
 import response.ResponseOuterClass.ConstantResponse;
 import response.ResponseOuterClass.Response;
 
@@ -76,8 +74,7 @@ public class ConnectionManagerTest {
                         .setReadFrom(ConnectionRequestOuterClass.ReadFrom.Primary)
                         .build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
-        Response response =
-                Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
+        Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
         completedFuture.complete(response);
 
         // execute
@@ -102,8 +99,7 @@ public class ConnectionManagerTest {
                         .setReadFrom(ConnectionRequestOuterClass.ReadFrom.Primary)
                         .build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
-        Response response =
-                Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
+        Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
         completedFuture.complete(response);
 
         // execute
@@ -163,8 +159,7 @@ public class ConnectionManagerTest {
                         .setDatabaseId(DATABASE_ID)
                         .build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
-        Response response =
-                Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
+        Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
         completedFuture.complete(response);
 
         // execute
@@ -182,8 +177,7 @@ public class ConnectionManagerTest {
         // setup
         RedisClientConfiguration redisClientConfiguration = RedisClientConfiguration.builder().build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
-        Response response =
-                Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
+        Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
         completedFuture.complete(response);
 
         // execute
@@ -226,9 +220,9 @@ public class ConnectionManagerTest {
         // execute
         when(channel.connect(any())).thenReturn(completedFuture);
         ExecutionException executionException =
-            assertThrows(
-                ExecutionException.class,
-                () -> connectionManager.connectToRedis(redisClientConfiguration).get());
+                assertThrows(
+                        ExecutionException.class,
+                        () -> connectionManager.connectToRedis(redisClientConfiguration).get());
 
         assertTrue(executionException.getCause() instanceof ClosingException);
         assertEquals("Unexpected data in response", executionException.getCause().getMessage());


### PR DESCRIPTION
1. Move error handling to `CallbackDispatcher`
2. Handle case of incorrect callback ID with `ClosingError` (ref: #851)
3. Close channel on `ClosingError`
4. Tests