### PR TITLE
Java: Add ExamplesApp and Update benchmarkingApp to both have Java/Glide-for-redis client

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -9,9 +9,10 @@ to develop this Java wrapper.
 
 The Java client contains the following parts:
 
-1. A Java client (lib folder): wrapper to rust client.
-2. A benchmark app: A dedicated benchmarking tool designed to evaluate and compare the performance of GLIDE for Redis and other Java clients.
-
+1. client: A Java-wrapper around the rust-core client.
+2. examples: An examples app to test the client against a Redis localhost
+3. benchmark: A dedicated benchmarking tool designed to evaluate and compare the performance of GLIDE for Redis and other Java clients.
+4. IntegTest: An integration test sub-project for API and E2E testing
 ## Installation and Setup
 
 ### Install from Gradle
@@ -84,6 +85,7 @@ Other useful gradle developer commands:
 * `./gradlew :client:test` to run client unit tests
 * `./gradlew spotlessCheck` to check for codestyle issues
 * `./gradlew spotlessApply` to apply codestyle recommendations
+* `./gradlew :examples:run` to run client examples
 * `./gradlew :benchmarks:run` to run performance benchmarks
 
 ## Basic Examples
@@ -91,19 +93,15 @@ Other useful gradle developer commands:
 ### Standalone Redis:
 
 ```java
-import glide.Client;
-import glide.Client.SingleResponse;
+import glide.api.RedisClient;
 
-Client client = new Client();
+RedisClient client = RedisClient.CreateClient();
 
-SingleResponse connect = client.asyncConnectToRedis("localhost", 6379);
-connect.await().isSuccess();
+CompletableFuture<Void> setResponse = client.set("key", "foobar");
+setResponse.get();
 
-SingleResponse set = client.asyncSet("key", "foobar");
-set.await().isSuccess();
-
-SingleResponse get = client.asyncGet("key");
-get.await().getValue() == "foobar";
+CompletableFuture<String> getResponse = client.get("key");
+getResponse.get() == "foobar";
 ```
 
 ### Benchmarks

--- a/java/benchmarks/build.gradle
+++ b/java/benchmarks/build.gradle
@@ -9,6 +9,8 @@ repositories {
 }
 
 dependencies {
+    implementation project(':client')
+
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:32.1.1-jre'
     implementation 'redis.clients:jedis:4.4.3'
@@ -23,4 +25,5 @@ dependencies {
 application {
     // Define the main class for the application.
     mainClass = 'glide.benchmarks.BenchmarkingApp'
+    applicationDefaultJvmArgs = ['-Djava.library.path=../target/release']
 }

--- a/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
@@ -3,6 +3,7 @@ package glide.benchmarks;
 
 import static glide.benchmarks.utils.Benchmarking.testClientSetGet;
 
+import glide.benchmarks.clients.glide.GlideAsyncClient;
 import glide.benchmarks.clients.jedis.JedisClient;
 import glide.benchmarks.clients.lettuce.LettuceAsyncClient;
 import java.util.Arrays;
@@ -56,7 +57,9 @@ public class BenchmarkingApp {
                     testClientSetGet(LettuceAsyncClient::new, runConfiguration, true);
                     break;
                 case GLIDE:
+                    // run testClientSetGet on GLIDE async client
                     System.out.println("GLIDE for Redis async not yet configured");
+                    testClientSetGet(GlideAsyncClient::new, runConfiguration, true);
                     break;
             }
         }

--- a/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
@@ -47,18 +47,15 @@ public class BenchmarkingApp {
         for (ClientName client : runConfiguration.clients) {
             switch (client) {
                 case JEDIS:
-                    // run testClientSetGet on JEDIS sync client
-                    System.out.println("Run JEDIS sync client");
+=                    System.out.println("Run JEDIS sync client");
                     testClientSetGet(JedisClient::new, runConfiguration, false);
                     break;
                 case LETTUCE:
-                    // run testClientSetGet on LETTUCE async client
-                    System.out.println("Run LETTUCE async client");
+=                    System.out.println("Run LETTUCE async client");
                     testClientSetGet(LettuceAsyncClient::new, runConfiguration, true);
                     break;
                 case GLIDE:
-                    // run testClientSetGet on GLIDE async client
-                    System.out.println("GLIDE for Redis async not yet configured");
+                    System.out.println("Run GLIDE async client");
                     testClientSetGet(GlideAsyncClient::new, runConfiguration, true);
                     break;
             }

--- a/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
@@ -47,11 +47,11 @@ public class BenchmarkingApp {
         for (ClientName client : runConfiguration.clients) {
             switch (client) {
                 case JEDIS:
-=                    System.out.println("Run JEDIS sync client");
+                    System.out.println("Run JEDIS sync client");
                     testClientSetGet(JedisClient::new, runConfiguration, false);
                     break;
                 case LETTUCE:
-=                    System.out.println("Run LETTUCE async client");
+                    System.out.println("Run LETTUCE async client");
                     testClientSetGet(LettuceAsyncClient::new, runConfiguration, true);
                     break;
                 case GLIDE:

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/glide/GlideAsyncClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/glide/GlideAsyncClient.java
@@ -1,0 +1,61 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.benchmarks.clients.glide;
+
+import glide.api.RedisClient;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RedisClientConfiguration;
+import glide.benchmarks.clients.AsyncClient;
+import glide.benchmarks.utils.ConnectionSettings;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/** A Glide client with async capabilities */
+public class GlideAsyncClient implements AsyncClient<String> {
+    private RedisClient redisClient;
+
+    @Override
+    public void connectToRedis(ConnectionSettings connectionSettings) {
+        if (connectionSettings.clusterMode) {
+            throw new RuntimeException("Use client GlideAsyncClusterClient");
+        }
+        RedisClientConfiguration config =
+                RedisClientConfiguration.builder()
+                        .address(
+                                NodeAddress.builder()
+                                        .host(connectionSettings.host)
+                                        .port(connectionSettings.port)
+                                        .build())
+                        .useTLS(connectionSettings.useSsl)
+                        .build();
+
+        try {
+            redisClient = RedisClient.CreateClient(config).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<String> asyncSet(String key, String value) {
+        return redisClient.customCommand(new String[] {"Set", key, value}).thenApply(r -> "Ok");
+    }
+
+    @Override
+    public CompletableFuture<String> asyncGet(String key) {
+        return redisClient.customCommand(new String[] {"Get", key}).thenApply(r -> (String) r);
+    }
+
+    @Override
+    public void closeConnection() {
+        try {
+            redisClient.close();
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "Glide Async";
+    }
+}

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/lettuce/LettuceAsyncClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/lettuce/LettuceAsyncClient.java
@@ -30,7 +30,7 @@ public class LettuceAsyncClient implements AsyncClient<String> {
                         .withPort(connectionSettings.port)
                         .withSsl(connectionSettings.useSsl)
                         .build();
-        if (connectionSettings.clusterMode) {
+        if (!connectionSettings.clusterMode) {
             client = RedisClient.create(uri);
             connection = ((RedisClient) client).connect();
             asyncCommands = ((StatefulRedisConnection<String, String>) connection).async();

--- a/java/examples/build.gradle
+++ b/java/examples/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
-    id 'application'}
+    id 'application'
+}
 
 group 'org.example'
 version '1.13.0'

--- a/java/examples/build.gradle
+++ b/java/examples/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    // Apply the application plugin to add support for building a CLI application in Java.
+    id 'application'}
+
+group 'org.example'
+version '1.13.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':client')
+
+    implementation 'redis.clients:jedis:4.4.3'
+    implementation 'io.lettuce:lettuce-core:6.2.6.RELEASE'
+    implementation 'commons-cli:commons-cli:1.5.0'
+}
+
+application {
+    // Define the main class for the application.
+    mainClass = 'glide.examples.ExamplesApp'
+    applicationDefaultJvmArgs = ['-Djava.library.path=../target/release']
+}

--- a/java/examples/src/main/java/glide/examples/ExamplesApp.java
+++ b/java/examples/src/main/java/glide/examples/ExamplesApp.java
@@ -1,0 +1,60 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.examples;
+
+import glide.api.RedisClient;
+import glide.examples.clients.GlideClient;
+import java.util.concurrent.ExecutionException;
+
+public class ExamplesApp {
+
+    // main application entrypoint
+    public static void main(String[] args) {
+        runGlideExamples();
+    }
+
+    private static void runGlideExamples() {
+        ConnectionSettings settings = new ConnectionSettings("localhost", 6379, false, false);
+
+        try {
+            RedisClient client = GlideClient.connectToGlide(settings);
+
+            System.out.println("Glide PING: " + client.customCommand(new String[] {"ping"}).get());
+            System.out.println(
+                    "Glide PING(custom): " + client.customCommand(new String[] {"ping", "found you!"}).get());
+
+            System.out.println("Glide INFO(): " + client.customCommand(new String[] {"info"}).get());
+
+            System.out.println(
+                    "Glide SET(myKey, myValue): "
+                            + client.customCommand(new String[] {"set", "myKey", "myValue"}).get());
+            System.out.println(
+                    "Glide GET(myKey): " + client.customCommand(new String[] {"get", "myKey"}).get());
+            System.out.println(
+                    "Glide SET(myKey, yourValue): "
+                            + client.customCommand(new String[] {"set", "myKey", "yourValue"}).get());
+            System.out.println(
+                    "Glide GET(myKey): " + client.customCommand(new String[] {"get", "myKey"}).get());
+            System.out.println(
+                    "Glide GET(invalid): " + client.customCommand(new String[] {"get", "invalid"}).get());
+
+        } catch (ExecutionException | InterruptedException e) {
+            System.out.println("Glide example failed with an exception: ");
+            e.printStackTrace();
+        }
+    }
+
+    /** Redis-client settings */
+    public static class ConnectionSettings {
+        public final String host;
+        public final int port;
+        public final boolean useSsl;
+        public final boolean clusterMode;
+
+        public ConnectionSettings(String host, int port, boolean useSsl, boolean clusterMode) {
+            this.host = host;
+            this.port = port;
+            this.useSsl = useSsl;
+            this.clusterMode = clusterMode;
+        }
+    }
+}

--- a/java/examples/src/main/java/glide/examples/clients/GlideClient.java
+++ b/java/examples/src/main/java/glide/examples/clients/GlideClient.java
@@ -1,0 +1,28 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.examples.clients;
+
+import glide.api.RedisClient;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RedisClientConfiguration;
+import glide.examples.ExamplesApp;
+import java.util.concurrent.ExecutionException;
+
+/** Connect to Jedis client. See: https://github.com/redis/jedis */
+public class GlideClient {
+    public static RedisClient connectToGlide(ExamplesApp.ConnectionSettings connectionSettings)
+            throws ExecutionException, InterruptedException {
+        if (connectionSettings.clusterMode) {
+            throw new RuntimeException("Not implemented");
+        }
+        RedisClientConfiguration config =
+                RedisClientConfiguration.builder()
+                        .address(
+                                NodeAddress.builder()
+                                        .host(connectionSettings.host)
+                                        .port(connectionSettings.port)
+                                        .build())
+                        .useTLS(connectionSettings.useSsl)
+                        .build();
+        return RedisClient.CreateClient(config).get();
+    }
+}

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -3,3 +3,5 @@ rootProject.name = 'glide'
 include 'client'
 include 'integTest'
 include 'benchmarks'
+include 'examples'
+


### PR DESCRIPTION
### Description

Add the Glide async client to the BenchmarkApp for the `install_and_test` script. 
Add the ExamplesApp for manually testing custom commands. 

### Out of scope

Glide async client doesn't have cluster-mode client linked (TODO). 
ExamplesApp runs only custom command (no transactions, no specific commands - TODO). 

### Examples: 

To run benchmark app, run: 
```
./gradlew :benchmarks:run --args="-clients GLIDE -dataSize 100 -concurrentTasks 100 -clientCount 1"
```

To run examples app, run: 
```
./gradlew :examples:run
```