### PR TITLE
Java: Add DEL command

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -150,12 +150,12 @@ public abstract class BaseClient
         return handleRedisResponse(String.class, true, response);
     }
 
-    protected Object[] handleArrayResponse(Response response) {
-        return handleRedisResponse(Object[].class, true, response);
+    protected Long handleLongResponse(Response response) throws RedisException {
+        return handleRedisResponse(Long.class, false, response);
     }
 
-    protected Integer handleIntegerResponse(Response response) throws RedisException {
-        return handleRedisResponse(Integer.class, false, response);
+    protected Object[] handleArrayResponse(Response response) {
+        return handleRedisResponse(Object[].class, true, response);
     }
 
     @Override
@@ -169,8 +169,8 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<Integer> del(@NonNull String[] keys) {
-        return commandManager.submitNewCommand(Del, keys, this::handleIntegerResponse);
+    public CompletableFuture<Long> del(@NonNull String[] keys) {
+        return commandManager.submitNewCommand(Del, keys, this::handleLongResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -2,6 +2,7 @@
 package glide.api;
 
 import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
+import static redis_request.RedisRequestOuterClass.RequestType.Del;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
@@ -153,6 +154,10 @@ public abstract class BaseClient
         return handleRedisResponse(Object[].class, true, response);
     }
 
+    protected Integer handleIntegerResponse(Response response) throws RedisException {
+        return handleRedisResponse(Integer.class, false, response);
+    }
+
     @Override
     public CompletableFuture<String> ping() {
         return commandManager.submitNewCommand(Ping, new String[0], this::handleStringResponse);
@@ -161,6 +166,11 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<String> ping(@NonNull String str) {
         return commandManager.submitNewCommand(Ping, new String[] {str}, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<Integer> del(@NonNull String[] keys) {
+        return commandManager.submitNewCommand(Del, keys, this::handleIntegerResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -8,6 +8,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.commands.ConnectionManagementCommands;
+import glide.api.commands.GenericBaseCommands;
 import glide.api.commands.StringCommands;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.configuration.BaseClientConfiguration;
@@ -33,7 +34,7 @@ import response.ResponseOuterClass.Response;
 /** Base Client class for Redis */
 @AllArgsConstructor
 public abstract class BaseClient
-        implements AutoCloseable, ConnectionManagementCommands, StringCommands {
+        implements AutoCloseable, GenericBaseCommands, ConnectionManagementCommands, StringCommands {
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
 

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -15,7 +15,7 @@ public interface GenericBaseCommands {
      *
      * @see <a href="https://redis.io/commands/del/">redis.io</a> for details.
      * @param keys the keys we wanted to remove.
-     * @returns the number of keys that were removed.
+     * @return the number of keys that were removed.
      */
     CompletableFuture<Long> del(String[] keys);
 }

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -1,0 +1,21 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generic Commands interface to handle generic commands for all server requests.
+ *
+ * @see <a href="https://redis.io/commands/?group=generic">Generic Commands</a>
+ */
+public interface GenericBaseCommands {
+
+    /**
+     * Removes the specified <code>keys</code>. A key is ignored if it does not exist.
+     *
+     * @see <a href="https://redis.io/commands/del/">redis.io</a> for details.
+     * @param keys the keys we wanted to remove.
+     * @returns the number of keys that were removed.
+     */
+    CompletableFuture<Long> del(String[] keys);
+}

--- a/java/client/src/main/java/glide/api/commands/StringCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringCommands.java
@@ -20,7 +20,7 @@ public interface StringCommands {
      * @param keys the keys we wanted to remove.
      * @returns the number of keys that were removed.
      */
-    CompletableFuture<Integer> del(String[] keys);
+    CompletableFuture<Long> del(String[] keys);
 
     /**
      * Get the value associated with the given <code>key</code>, or <code>null</code> if no such value

--- a/java/client/src/main/java/glide/api/commands/StringCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringCommands.java
@@ -14,15 +14,6 @@ import java.util.concurrent.CompletableFuture;
 public interface StringCommands {
 
     /**
-     * Removes the specified <code>keys</code>. A key is ignored if it does not exist.
-     *
-     * @see <a href="https://redis.io/commands/del/">redis.io</a> for details.
-     * @param keys the keys we wanted to remove.
-     * @returns the number of keys that were removed.
-     */
-    CompletableFuture<Long> del(String[] keys);
-
-    /**
      * Get the value associated with the given <code>key</code>, or <code>null</code> if no such value
      * exists.
      *

--- a/java/client/src/main/java/glide/api/commands/StringCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringCommands.java
@@ -14,6 +14,15 @@ import java.util.concurrent.CompletableFuture;
 public interface StringCommands {
 
     /**
+     * Removes the specified <code>keys</code>. A key is ignored if it does not exist.
+     *
+     * @see <a href="https://redis.io/commands/del/">redis.io</a> for details.
+     * @param keys the keys we wanted to remove.
+     * @returns the number of keys that were removed.
+     */
+    CompletableFuture<Integer> del(String[] keys);
+
+    /**
      * Get the value associated with the given <code>key</code>, or <code>null</code> if no such value
      * exists.
      *

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -2,6 +2,7 @@
 package glide.api.models;
 
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
+import static redis_request.RedisRequestOuterClass.RequestType.Del;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -111,6 +112,20 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
         ArgsArray commandArgs = buildArgs(options.toArgs());
 
         protobufTransaction.addCommands(buildCommand(Info, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Removes the specified <code>keys</code>. A key is ignored if it does not exist.
+     *
+     * @see <a href="https://redis.io/commands/del/">redis.io</a> for details.
+     * @param keys the keys we wanted to remove.
+     * @returns the number of keys that were removed.
+     */
+    public T del(String[] keys) {
+        ArgsArray commandArgs = buildArgs(keys);
+
+        protobufTransaction.addCommands(buildCommand(Del, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -120,7 +120,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://redis.io/commands/del/">redis.io</a> for details.
      * @param keys the keys we wanted to remove.
-     * @returns the number of keys that were removed.
+     * @return the number of keys that were removed.
      */
     public T del(String[] keys) {
         ArgsArray commandArgs = buildArgs(keys);

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -111,7 +111,7 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
-    public void del_returns_integer_success() {
+    public void del_returns_long_success() {
         // setup
         String[] keys = new String[] {"testKey1", "testKey2"};
         Long numberDeleted = 1L;

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
+import static redis_request.RedisRequestOuterClass.RequestType.Del;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -106,6 +107,26 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(message, pong);
+    }
+
+    @SneakyThrows
+    @Test
+    public void del_returns_integer_success() {
+        // setup
+        String[] keys = new String[] {"testKey1", "testKey2"};
+        Integer numberDeleted = 1;
+        CompletableFuture<Integer> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(numberDeleted);
+        when(commandManager.<Integer>submitNewCommand(eq(Del), eq(keys), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Integer> response = service.del(keys);
+        Integer result = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(numberDeleted, result);
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -114,15 +114,14 @@ public class RedisClientTest {
     public void del_returns_integer_success() {
         // setup
         String[] keys = new String[] {"testKey1", "testKey2"};
-        Integer numberDeleted = 1;
-        CompletableFuture<Integer> testResponse = mock(CompletableFuture.class);
+        Long numberDeleted = 1L;
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn(numberDeleted);
-        when(commandManager.<Integer>submitNewCommand(eq(Del), eq(keys), any()))
-                .thenReturn(testResponse);
+        when(commandManager.<Long>submitNewCommand(eq(Del), eq(keys), any())).thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Integer> response = service.del(keys);
-        Integer result = response.get();
+        CompletableFuture<Long> response = service.del(keys);
+        Long result = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -3,6 +3,7 @@ package glide.api.models;
 
 import static glide.api.models.commands.SetOptions.RETURN_OLD_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static redis_request.RedisRequestOuterClass.RequestType.Del;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -41,6 +42,9 @@ public class ClusterTransactionTests {
                                 .addArgs("value")
                                 .addArgs(RETURN_OLD_VALUE)
                                 .build()));
+
+        transaction.del(new String[] {"key1", "key2"});
+        results.add(Pair.of(Del, ArgsArray.newBuilder().addArgs("key1").addArgs("key2").build()));
 
         transaction.ping();
         results.add(Pair.of(Ping, ArgsArray.newBuilder().build()));

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -3,6 +3,7 @@ package glide.api.models;
 
 import static glide.api.models.commands.SetOptions.RETURN_OLD_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static redis_request.RedisRequestOuterClass.RequestType.Del;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -40,6 +41,9 @@ public class TransactionTests {
                                 .addArgs("value")
                                 .addArgs(RETURN_OLD_VALUE)
                                 .build()));
+
+        transaction.del(new String[] {"key1", "key2"});
+        results.add(Pair.of(Del, ArgsArray.newBuilder().addArgs("key1").addArgs("key2").build()));
 
         transaction.ping();
         results.add(Pair.of(Ping, ArgsArray.newBuilder().build()));

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -19,6 +19,7 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
 import java.util.List;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -101,6 +102,34 @@ public class SharedCommandTests {
     public void get_missing_value(BaseClient client) {
         String data = client.get("invalid").get();
         assertNull(data);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void del_multiple_keys(BaseClient client) {
+        String key1 = "{key}" + UUID.randomUUID();
+        String key2 = "{key}" + UUID.randomUUID();
+        String key3 = "{key}" + UUID.randomUUID();
+        String value = UUID.randomUUID().toString();
+
+        String setResult = client.set(key1, value).get();
+        assertEquals(OK, setResult);
+        setResult = client.set(key2, value).get();
+        assertEquals(OK, setResult);
+        setResult = client.set(key3, value).get();
+        assertEquals(OK, setResult);
+
+        Integer deletedKeysNum = client.del(new String[] {key1, key2, key3}).get();
+        assertEquals(3, deletedKeysNum);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void del_non_existent_key(BaseClient client) {
+        Integer deletedKeysNum = client.del(new String[] {UUID.randomUUID().toString()}).get();
+        assertEquals(0, deletedKeysNum);
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -120,16 +120,16 @@ public class SharedCommandTests {
         setResult = client.set(key3, value).get();
         assertEquals(OK, setResult);
 
-        Integer deletedKeysNum = client.del(new String[] {key1, key2, key3}).get();
-        assertEquals(3, deletedKeysNum);
+        Long deletedKeysNum = client.del(new String[] {key1, key2, key3}).get();
+        assertEquals(3L, deletedKeysNum);
     }
 
     @SneakyThrows
     @ParameterizedTest
     @MethodSource("getClients")
     public void del_non_existent_key(BaseClient client) {
-        Integer deletedKeysNum = client.del(new String[] {UUID.randomUUID().toString()}).get();
-        assertEquals(0, deletedKeysNum);
+        Long deletedKeysNum = client.del(new String[] {UUID.randomUUID().toString()}).get();
+        assertEquals(0L, deletedKeysNum);
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -14,11 +14,12 @@ public class TestUtilities {
         baseTransaction.set(key1, "bar");
         baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
+        baseTransaction.del(new String[] {key1});
 
         return baseTransaction;
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {"OK", null, new String[] {"bar", "baz"}};
+        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 1L};
     }
 }


### PR DESCRIPTION
Adding the DEL() command (String command)

Example: 
```
// assuming key1 and key2 exist, while key "invalid" does not. 
Integer result = client.del(new String[] {"key1", "key2", "invalid"}).get();
assert result == 2;
```