### PR TITLE
Java: Add EXISTS() command

### DIFF
--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -1,0 +1,22 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generic Commands interface to handle generic commands for all server requests.
+ *
+ * @see <a href="https://redis.io/commands/?group=generic">Generic Commands</a>
+ */
+public interface GenericBaseCommands {
+
+    /**
+     * Returns the number of keys in <code>keys</code> that exist in the database.
+     *
+     * @see @see <a href="https://redis.io/commands/exists/">redis.io</a> for details.
+     * @param keys The keys list to check.
+     * @returns the number of keys that exist. If the same existing key is mentioned in <code>keys
+     *     </code> multiple times, it will be counted multiple times.
+     */
+    CompletableFuture<Long> exists(String[] keys);
+}

--- a/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
@@ -10,6 +10,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Generic Commands interface to handle generic command and transaction requests with routing
  * options.
+ *
+ * @see <a href="https://redis.io/commands/?group=generic">Generic Commands</a>
  */
 public interface GenericClusterCommands {
 

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -4,7 +4,11 @@ package glide.api.commands;
 import glide.api.models.Transaction;
 import java.util.concurrent.CompletableFuture;
 
-/** Generic Commands interface to handle generic command and transaction requests. */
+/**
+ * Generic Commands interface to handle generic command and transaction requests.
+ *
+ * @see <a href="https://redis.io/commands/?group=generic">Generic Commands</a>
+ */
 public interface GenericCommands {
 
     /**

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -2,6 +2,7 @@
 package glide.api.models;
 
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
+import static redis_request.RedisRequestOuterClass.RequestType.Exists;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -162,6 +163,21 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
                 buildArgs(ArrayUtils.addAll(new String[] {key, value}, options.toArgs()));
 
         protobufTransaction.addCommands(buildCommand(SetString, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns the number of keys in <code>keys</code> that exist in the database.
+     *
+     * @see @see <a href="https://redis.io/commands/exists/">redis.io</a> for details.
+     * @param keys The keys list to check.
+     * @returns the number of keys that exist. If the same existing key is mentioned in <code>keys
+     *     </code> multiple times, it will be counted multiple times.
+     */
+    public T exists(String[] keys) {
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addAll(keys));
+
+        protobufTransaction.addCommands(buildCommand(Exists, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
+import static redis_request.RedisRequestOuterClass.RequestType.Exists;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -202,6 +203,26 @@ public class RedisClientTest {
         // verify
         assertNotNull(response);
         assertEquals(value, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void exists_returns_long_success() {
+        // setup
+        String[] keys = new String[] {"testKey1", "testKey2"};
+        Long numberExisting = 1L;
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(numberExisting);
+        when(commandManager.<Long>submitNewCommand(eq(Exists), eq(keys), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.exists(keys);
+        Long result = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(numberExisting, result);
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -3,6 +3,7 @@ package glide.api.models;
 
 import static glide.api.models.commands.SetOptions.RETURN_OLD_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static redis_request.RedisRequestOuterClass.RequestType.Exists;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -41,6 +42,9 @@ public class ClusterTransactionTests {
                                 .addArgs("value")
                                 .addArgs(RETURN_OLD_VALUE)
                                 .build()));
+
+        transaction.exists(new String[] {"key1", "key2"});
+        results.add(Pair.of(Exists, ArgsArray.newBuilder().addArgs("key1").addArgs("key2").build()));
 
         transaction.ping();
         results.add(Pair.of(Ping, ArgsArray.newBuilder().build()));

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -3,6 +3,7 @@ package glide.api.models;
 
 import static glide.api.models.commands.SetOptions.RETURN_OLD_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static redis_request.RedisRequestOuterClass.RequestType.Exists;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -40,6 +41,9 @@ public class TransactionTests {
                                 .addArgs("value")
                                 .addArgs(RETURN_OLD_VALUE)
                                 .build()));
+
+        transaction.exists(new String[] {"key1", "key2"});
+        results.add(Pair.of(Exists, ArgsArray.newBuilder().addArgs("key1").addArgs("key2").build()));
 
         transaction.ping();
         results.add(Pair.of(Ping, ArgsArray.newBuilder().build()));

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -19,6 +19,7 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
 import java.util.List;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -246,5 +247,30 @@ public class SharedCommandTests {
         SetOptions options = SetOptions.builder().returnOldValue(true).build();
         String data = client.set("another", ANOTHER_VALUE, options).get();
         assertNull(data);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void exists_multiple_keys(BaseClient client) {
+        String key1 = "{key}" + UUID.randomUUID();
+        String key2 = "{key}" + UUID.randomUUID();
+        String value = UUID.randomUUID().toString();
+
+        String setResult = client.set(key1, value).get();
+        assertEquals(OK, setResult);
+        setResult = client.set(key2, value).get();
+        assertEquals(OK, setResult);
+
+        Long existsKeysNum = client.exists(new String[] {key1, key2, key1}).get();
+        assertEquals(3L, existsKeysNum);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void del_non_existent_key(BaseClient client) {
+        Long existsKeysNum = client.exists(new String[] {UUID.randomUUID().toString()}).get();
+        assertEquals(0L, existsKeysNum);
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -10,15 +10,18 @@ public class TestUtilities {
     public static BaseTransaction transactionTest(BaseTransaction baseTransaction) {
         String key1 = "{key}" + UUID.randomUUID();
         String key2 = "{key}" + UUID.randomUUID();
+        String value1 = UUID.randomUUID().toString();
+        String value2 = UUID.randomUUID().toString();
 
-        baseTransaction.set(key1, "bar");
-        baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
+        baseTransaction.set(key1, "apples");
+        baseTransaction.set(key2, "bananas", SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
+        baseTransaction.exists(new String[] {key1, key2});
 
         return baseTransaction;
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {"OK", null, new String[] {"bar", "baz"}};
+        return new Object[] {"OK", null, new String[] {"apples", "bananas"}, 2L};
     }
 }


### PR DESCRIPTION
Adding the EXISTS() command (Generic command)

Example: 
```
// assuming key1 and key2 exist, while key "invalid" does not. 
// note: result will be 3 because key1 is listed twice
Integer result = client.exists(new String[] {"key1", "key2", "key1", "invalid"}).get();
assert result == 3L;
```