### PR TITLE
Java: Add SADD, SREM, SMEMBERS, and SCARD commands (Set Commands)

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -4,9 +4,12 @@ package glide.api;
 import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.commands.ConnectionManagementCommands;
+import glide.api.commands.SetCommands;
 import glide.api.commands.StringCommands;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.configuration.BaseClientConfiguration;
@@ -32,7 +35,7 @@ import response.ResponseOuterClass.Response;
 /** Base Client class for Redis */
 @AllArgsConstructor
 public abstract class BaseClient
-        implements AutoCloseable, ConnectionManagementCommands, StringCommands {
+        implements AutoCloseable, ConnectionManagementCommands, StringCommands, SetCommands {
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
 
@@ -149,6 +152,10 @@ public abstract class BaseClient
         return handleRedisResponse(String.class, true, response);
     }
 
+    protected Long handleLongResponse(Response response) throws RedisException {
+        return handleRedisResponse(Long.class, false, response);
+    }
+
     protected Object[] handleArrayResponse(Response response) {
         return handleRedisResponse(Object[].class, true, response);
     }
@@ -180,5 +187,17 @@ public abstract class BaseClient
             @NonNull String key, @NonNull String value, @NonNull SetOptions options) {
         String[] arguments = ArrayUtils.addAll(new String[] {key, value}, options.toArgs());
         return commandManager.submitNewCommand(SetString, arguments, this::handleStringOrNullResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> sadd(String key, String[] members) {
+        String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
+        return commandManager.submitNewCommand(SAdd, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> srem(String key, String[] members) {
+        String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
+        return commandManager.submitNewCommand(SRem, arguments, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -190,14 +190,14 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<Long> sadd(String key, String[] members) {
-        String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
+    public CompletableFuture<Long> sadd(String key, String... members) {
+        String[] arguments = ArrayUtils.addFirst(members, key);
         return commandManager.submitNewCommand(SAdd, arguments, this::handleLongResponse);
     }
 
     @Override
-    public CompletableFuture<Long> srem(String key, String[] members) {
-        String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
+    public CompletableFuture<Long> srem(String key, String... members) {
+        String[] arguments = ArrayUtils.addFirst(members, key);
         return commandManager.submitNewCommand(SRem, arguments, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -5,6 +5,8 @@ import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
@@ -23,6 +25,7 @@ import glide.ffi.resolvers.RedisValueResolver;
 import glide.managers.BaseCommandResponseResolver;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
@@ -160,6 +163,10 @@ public abstract class BaseClient
         return handleRedisResponse(Object[].class, true, response);
     }
 
+    protected Set<String> handleSetResponse(Response response) {
+        return handleRedisResponse(Set.class, false, response);
+    }
+
     @Override
     public CompletableFuture<String> ping() {
         return commandManager.submitNewCommand(Ping, new String[0], this::handleStringResponse);
@@ -199,5 +206,15 @@ public abstract class BaseClient
     public CompletableFuture<Long> srem(String key, String... members) {
         String[] arguments = ArrayUtils.addFirst(members, key);
         return commandManager.submitNewCommand(SRem, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> smembers(String key) {
+        return commandManager.submitNewCommand(SMembers, new String[] {key}, this::handleSetResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> scard(String key) {
+        return commandManager.submitNewCommand(SCard, new String[] {key}, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -197,13 +197,13 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<Long> sadd(String key, String... members) {
+    public CompletableFuture<Long> sadd(String key, String[] members) {
         String[] arguments = ArrayUtils.addFirst(members, key);
         return commandManager.submitNewCommand(SAdd, arguments, this::handleLongResponse);
     }
 
     @Override
-    public CompletableFuture<Long> srem(String key, String... members) {
+    public CompletableFuture<Long> srem(String key, String[] members) {
         String[] arguments = ArrayUtils.addFirst(members, key);
         return commandManager.submitNewCommand(SRem, arguments, this::handleLongResponse);
     }

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
+ */
+package glide.api.commands;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Set Commands interface.
+ *
+ * @see <a href="https://redis.io/commands/?group=set">Set Commands</a>
+ */
+public interface SetCommands {
+    /**
+     * Add specified members to the set stored at <code>key</code>.
+     * Specified members that are already a member of this set are ignored.
+     *
+     * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
+     * @param key The <code>key</code> where members will be added to its set.
+     * @param members A list of members to add to the set stored at <code>key</code>.
+     * @return The number of members that were added to the set, excluding members already present.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
+     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *     </ul>
+     *
+     *
+     *
+     * @example
+     *     <p><code>
+     *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();
+     *  </code>
+     */
+    CompletableFuture<Long> sadd(String key, String[] members);
+
+    /**
+     * Remove specified members from the set stored at <code>key</code>.
+     * Specified members that are not a member of this set are ignored.
+     *
+     * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
+     * @param key The <code>key</code> from which members will be removed.
+     * @param members A list of members to remove from the set stored at <code>key</code>.
+     * @return The number of members that were removed from the set, excluding non-existing members.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command returns 0.
+     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *     </ul>
+     *
+     * @example
+     *     <p><code>
+     *  int result = client.srem("my_set", new String[]{"member1", "member2"}).get();
+     *  </code>
+     */
+    CompletableFuture<Long> srem(String key, String[] members);
+}

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -1,6 +1,7 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.commands;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -51,5 +52,38 @@ public interface SetCommands {
      *  int result = client.srem("my_set", new String[]{"member1", "member2"}).get();
      *  </code>
      */
-    CompletableFuture<Long> srem(String key, String[] members);
+    CompletableFuture<Long> srem(String key, String... members);
+
+    /**
+     * Retrieve all the members of the set value stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
+     * @param key The key from which to retrieve the set members.
+     * @return A set of all members of the set.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist an empty list will be returned.
+     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *     </ul>
+     *
+     * @example
+     *     <p><code>
+     *  {@literal Set<String>} result = client.smembers("my_set").get();
+     *  </code>
+     */
+    CompletableFuture<Set<String>> smembers(String key);
+
+    /**
+     * Retrieve the set cardinality (number of elements) of the set stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
+     * @param key The key from which to retrieve the number of set members.
+     * @return The cardinality (number of elements) of the set, or 0 if the key does not exist.
+     * @remarks If <code>key</code> holds a value that is not a set, an error is returned.
+     * @example
+     *     <p><code>
+     *  int result = client.scard("my_set").get();
+     *  </code>
+     */
+    CompletableFuture<Long> scard(String key);
 }

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -29,7 +29,7 @@ public interface SetCommands {
      *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();
      *  </code>
      */
-    CompletableFuture<Long> sadd(String key, String[] members);
+    CompletableFuture<Long> sadd(String key, String... members);
 
     /**
      * Remove specified members from the set stored at <code>key</code>. Specified members that are

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -30,7 +30,7 @@ public interface SetCommands {
      *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();
      *  </code>
      */
-    CompletableFuture<Long> sadd(String key, String... members);
+    CompletableFuture<Long> sadd(String key, String[] members);
 
     /**
      * Remove specified members from the set stored at <code>key</code>. Specified members that are
@@ -52,17 +52,17 @@ public interface SetCommands {
      *  int result = client.srem("my_set", new String[]{"member1", "member2"}).get();
      *  </code>
      */
-    CompletableFuture<Long> srem(String key, String... members);
+    CompletableFuture<Long> srem(String key, String[] members);
 
     /**
      * Retrieve all the members of the set value stored at <code>key</code>.
      *
      * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
      * @param key The key from which to retrieve the set members.
-     * @return A set of all members of the set.
+     * @return A <code>Set</code> of all members of the set.
      * @remarks
      *     <ul>
-     *       <li>If <code>key</code> does not exist an empty list will be returned.
+     *       <li>If <code>key</code> does not exist an empty set will be returned.
      *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
      *     </ul>
      *

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -26,8 +26,6 @@ public interface SetCommands {
      *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
      *     </ul>
      *
-     *
-     *
      * @example
      *     <p><code>
      *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -1,9 +1,6 @@
-/**
- * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
- */
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.commands;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -13,8 +10,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface SetCommands {
     /**
-     * Add specified members to the set stored at <code>key</code>.
-     * Specified members that are already a member of this set are ignored.
+     * Add specified members to the set stored at <code>key</code>. Specified members that are already
+     * a member of this set are ignored.
      *
      * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
      * @param key The <code>key</code> where members will be added to its set.
@@ -22,7 +19,8 @@ public interface SetCommands {
      * @return The number of members that were added to the set, excluding members already present.
      * @remarks
      *     <ul>
-     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
+     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members
+     *           </code>.
      *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
      *     </ul>
      *
@@ -34,8 +32,8 @@ public interface SetCommands {
     CompletableFuture<Long> sadd(String key, String[] members);
 
     /**
-     * Remove specified members from the set stored at <code>key</code>.
-     * Specified members that are not a member of this set are ignored.
+     * Remove specified members from the set stored at <code>key</code>. Specified members that are
+     * not a member of this set are ignored.
      *
      * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
      * @param key The <code>key</code> from which members will be removed.
@@ -43,7 +41,8 @@ public interface SetCommands {
      * @return The number of members that were removed from the set, excluding non-existing members.
      * @remarks
      *     <ul>
-     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command returns 0.
+     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command
+     *           returns 0.
      *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
      *     </ul>
      *

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -176,7 +176,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
      * @param key The <code>key</code> where members will be added to its set.
      * @param members A list of members to add to the set stored at <code>key</code>.
-     * @return CommandResponse - The number of members that were added to the set, excluding members
+     * @return Command Response - The number of members that were added to the set, excluding members
      *     already present.
      * @remarks
      *     <ul>
@@ -199,7 +199,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
      * @param key The <code>key</code> from which members will be removed.
      * @param members A list of members to remove from the set stored at <code>key</code>.
-     * @return CommandResponse - The number of members that were removed from the set, excluding
+     * @return Command Response - The number of members that were removed from the set, excluding
      *     non-existing members.
      * @remarks
      *     <ul>
@@ -220,7 +220,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
      * @param key The key from which to retrieve the set members.
-     * @return CommandResponse - A set of all members of the set.
+     * @return Command Response - A set of all members of the set.
      * @remarks
      *     <ul>
      *       <li>If <code>key</code> does not exist an empty list will be returned.
@@ -239,7 +239,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
      * @param key The key from which to retrieve the number of set members.
-     * @return The cardinality (number of elements) of the set, or 0 if the key does not exist.
+     * @return Command Response - The cardinality (number of elements) of the set, or 0 if the key
+     *     does not exist.
      * @remarks If <code>key</code> holds a value that is not a set, the transaction fails.
      */
     public T scard(String key) {

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -174,12 +174,12 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
      * @param key The <code>key</code> where members will be added to its set.
      * @param members A list of members to add to the set stored at <code>key</code>.
-     * @return The number of members that were added to the set, excluding members already present.
+     * @return CommandResponse - The number of members that were added to the set, excluding members already present.
      * @remarks
      *     <ul>
      *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members
      *           </code>.
-     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
      *     </ul>
      *
      * @example
@@ -188,7 +188,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *  </code>
      */
     public T sadd(String key, String... members) {
-        ArgsArray commandArgs = buildArgs(ArrayUtils.addAll(new String[] {key}, members));
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
 
         protobufTransaction.addCommands(buildCommand(SAdd, commandArgs));
         return getThis();
@@ -201,12 +201,12 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
      * @param key The <code>key</code> from which members will be removed.
      * @param members A list of members to remove from the set stored at <code>key</code>.
-     * @return The number of members that were removed from the set, excluding non-existing members.
+     * @return CommandResponse - The number of members that were removed from the set, excluding non-existing members.
      * @remarks
      *     <ul>
      *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command
      *           returns 0.
-     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
      *     </ul>
      *
      * @example
@@ -215,7 +215,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *  </code>
      */
     public T srem(String key, String... members) {
-        ArgsArray commandArgs = buildArgs(ArrayUtils.addAll(new String[] {key}, members));
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
 
         protobufTransaction.addCommands(buildCommand(SRem, commandArgs));
         return getThis();

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -185,7 +185,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
      *     </ul>
      */
-    public T sadd(String key, String... members) {
+    public T sadd(String key, String[] members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
 
         protobufTransaction.addCommands(buildCommand(SAdd, commandArgs));
@@ -208,7 +208,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
      *     </ul>
      */
-    public T srem(String key, String... members) {
+    public T srem(String key, String[] members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
 
         protobufTransaction.addCommands(buildCommand(SRem, commandArgs));
@@ -220,10 +220,10 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
      * @param key The key from which to retrieve the set members.
-     * @return Command Response - A set of all members of the set.
+     * @return Command Response - A <code>Set</code> of all members of the set.
      * @remarks
      *     <ul>
-     *       <li>If <code>key</code> does not exist an empty list will be returned.
+     *       <li>If <code>key</code> does not exist an empty set will be returned.
      *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
      *     </ul>
      */

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -174,7 +174,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
      * @param key The <code>key</code> where members will be added to its set.
      * @param members A list of members to add to the set stored at <code>key</code>.
-     * @return CommandResponse - The number of members that were added to the set, excluding members already present.
+     * @return CommandResponse - The number of members that were added to the set, excluding members
+     *     already present.
      * @remarks
      *     <ul>
      *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members
@@ -201,7 +202,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
      * @param key The <code>key</code> from which members will be removed.
      * @param members A list of members to remove from the set stored at <code>key</code>.
-     * @return CommandResponse - The number of members that were removed from the set, excluding non-existing members.
+     * @return CommandResponse - The number of members that were removed from the set, excluding
+     *     non-existing members.
      * @remarks
      *     <ul>
      *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -15,14 +15,11 @@ import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.SetOptions.ConditionalSet;
 import glide.api.models.commands.SetOptions.SetOptionsBuilder;
 import lombok.Getter;
-import lombok.NonNull;
 import org.apache.commons.lang3.ArrayUtils;
 import redis_request.RedisRequestOuterClass.Command;
 import redis_request.RedisRequestOuterClass.Command.ArgsArray;
 import redis_request.RedisRequestOuterClass.RequestType;
 import redis_request.RedisRequestOuterClass.Transaction;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Base class encompassing shared commands for both standalone and cluster mode implementations in a
@@ -171,8 +168,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Add specified members to the set stored at <code>key</code>.
-     * Specified members that are already a member of this set are ignored.
+     * Add specified members to the set stored at <code>key</code>. Specified members that are already
+     * a member of this set are ignored.
      *
      * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
      * @param key The <code>key</code> where members will be added to its set.
@@ -180,7 +177,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @return The number of members that were added to the set, excluding members already present.
      * @remarks
      *     <ul>
-     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
+     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members
+     *           </code>.
      *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
      *     </ul>
      *
@@ -190,16 +188,15 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *  </code>
      */
     public T sadd(String key, String[] members) {
-        ArgsArray commandArgs =
-            buildArgs(ArrayUtils.addAll(new String[] {key}, members));
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addAll(new String[] {key}, members));
 
         protobufTransaction.addCommands(buildCommand(SAdd, commandArgs));
         return getThis();
     }
 
     /**
-     * Remove specified members from the set stored at <code>key</code>.
-     * Specified members that are not a member of this set are ignored.
+     * Remove specified members from the set stored at <code>key</code>. Specified members that are
+     * not a member of this set are ignored.
      *
      * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
      * @param key The <code>key</code> from which members will be removed.
@@ -207,7 +204,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @return The number of members that were removed from the set, excluding non-existing members.
      * @remarks
      *     <ul>
-     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command returns 0.
+     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command
+     *           returns 0.
      *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
      *     </ul>
      *
@@ -217,8 +215,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *  </code>
      */
     public T srem(String key, String[] members) {
-        ArgsArray commandArgs =
-            buildArgs(ArrayUtils.addAll(new String[] {key}, members));
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addAll(new String[] {key}, members));
 
         protobufTransaction.addCommands(buildCommand(SRem, commandArgs));
         return getThis();

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -187,7 +187,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();
      *  </code>
      */
-    public T sadd(String key, String[] members) {
+    public T sadd(String key, String... members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addAll(new String[] {key}, members));
 
         protobufTransaction.addCommands(buildCommand(SAdd, commandArgs));
@@ -214,7 +214,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *  int result = client.srem("my_set", new String[]{"member1", "member2"}).get();
      *  </code>
      */
-    public T srem(String key, String[] members) {
+    public T srem(String key, String... members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addAll(new String[] {key}, members));
 
         protobufTransaction.addCommands(buildCommand(SRem, commandArgs));

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -6,6 +6,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
@@ -182,11 +184,6 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *           </code>.
      *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
      *     </ul>
-     *
-     * @example
-     *     <p><code>
-     *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();
-     *  </code>
      */
     public T sadd(String key, String... members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
@@ -210,16 +207,45 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *           returns 0.
      *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
      *     </ul>
-     *
-     * @example
-     *     <p><code>
-     *  int result = client.srem("my_set", new String[]{"member1", "member2"}).get();
-     *  </code>
      */
     public T srem(String key, String... members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
 
         protobufTransaction.addCommands(buildCommand(SRem, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Retrieve all the members of the set value stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
+     * @param key The key from which to retrieve the set members.
+     * @return CommandResponse - A set of all members of the set.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist an empty list will be returned.
+     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
+     *     </ul>
+     */
+    public T smembers(String key) {
+        ArgsArray commandArgs = buildArgs(key);
+
+        protobufTransaction.addCommands(buildCommand(SMembers, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Retrieve the set cardinality (number of elements) of the set stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
+     * @param key The key from which to retrieve the number of set members.
+     * @return The cardinality (number of elements) of the set, or 0 if the key does not exist.
+     * @remarks If <code>key</code> holds a value that is not a set, the transaction fails.
+     */
+    public T scard(String key) {
+        ArgsArray commandArgs = buildArgs(key);
+
+        protobufTransaction.addCommands(buildCommand(SCard, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -173,13 +173,16 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Add specified members to the set stored at <code>key</code>.
      * Specified members that are already a member of this set are ignored.
-     * If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
      *
      * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
      * @param key The <code>key</code> where members will be added to its set.
      * @param members A list of members to add to the set stored at <code>key</code>.
-     * @return A list of members to add to the set stored at <code>key</code>>.
-     * @remarks If <code>key</code> holds a value that is not a set, an error is returned.
+     * @return The number of members that were added to the set, excluding members already present.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
+     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *     </ul>
      *
      * @example
      *     <p><code>

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -26,8 +26,6 @@ import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.SetOptions.Expiry;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.SneakyThrows;
@@ -331,7 +329,7 @@ public class RedisClientTest {
     public void smembers_returns_success() {
         // setup
         String key = "testKey";
-        Set<String> value = new HashSet<>(Arrays.asList("testMember"));
+        Set<String> value = Set.of("testMember");
 
         CompletableFuture testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn(value);

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -277,7 +277,7 @@ public class RedisClientTest {
         // setup
         String key = "testKey";
         String[] members = new String[] {"testMember1", "testMember2"};
-        String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
+        String[] arguments = ArrayUtils.addFirst(members, key);
         Long value = 2L;
 
         CompletableFuture testResponse = mock(CompletableFuture.class);
@@ -302,7 +302,7 @@ public class RedisClientTest {
         // setup
         String key = "testKey";
         String[] members = new String[] {"testMember1", "testMember2"};
-        String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
+        String[] arguments = ArrayUtils.addFirst(members, key);
         Long value = 2L;
 
         CompletableFuture testResponse = mock(CompletableFuture.class);

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -16,6 +16,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
@@ -24,6 +26,9 @@ import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.SetOptions.Expiry;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.ArrayUtils;
@@ -314,6 +319,52 @@ public class RedisClientTest {
 
         // exercise
         CompletableFuture<Long> response = service.srem(key, members);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void smembers_returns_success() {
+        // setup
+        String key = "testKey";
+        Set<String> value = new HashSet<>(Arrays.asList("testMember"));
+
+        CompletableFuture testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(SMembers), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Set<String>> response = service.smembers(key);
+        Set<String> payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void scard_returns_success() {
+        // setup
+        String key = "testKey";
+        Long value = 2L;
+
+        CompletableFuture testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(SCard), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.scard(key);
         Long payload = response.get();
 
         // verify

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -283,11 +283,11 @@ public class RedisClientTest {
         String[] arguments = ArrayUtils.addFirst(members, key);
         Long value = 2L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn(value);
 
         // match on protobuf request
-        when(commandManager.<String>submitNewCommand(eq(SAdd), eq(arguments), any()))
+        when(commandManager.<Long>submitNewCommand(eq(SAdd), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -308,11 +308,11 @@ public class RedisClientTest {
         String[] arguments = ArrayUtils.addFirst(members, key);
         Long value = 2L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn(value);
 
         // match on protobuf request
-        when(commandManager.<String>submitNewCommand(eq(SRem), eq(arguments), any()))
+        when(commandManager.<Long>submitNewCommand(eq(SRem), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -331,11 +331,11 @@ public class RedisClientTest {
         String key = "testKey";
         Set<String> value = Set.of("testMember");
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
+        CompletableFuture<Set<String>> testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn(value);
 
         // match on protobuf request
-        when(commandManager.<String>submitNewCommand(eq(SMembers), eq(new String[] {key}), any()))
+        when(commandManager.<Set<String>>submitNewCommand(eq(SMembers), eq(new String[] {key}), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -354,11 +354,11 @@ public class RedisClientTest {
         String key = "testKey";
         Long value = 2L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn(value);
 
         // match on protobuf request
-        when(commandManager.<String>submitNewCommand(eq(SCard), eq(new String[] {key}), any()))
+        when(commandManager.<Long>submitNewCommand(eq(SCard), eq(new String[] {key}), any()))
                 .thenReturn(testResponse);
 
         // exercise

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -15,6 +15,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.models.commands.InfoOptions;
@@ -24,6 +26,7 @@ import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
 import java.util.concurrent.CompletableFuture;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -266,5 +269,55 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(testPayload, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void sadd_returns_success() {
+        // setup
+        String key = "testKey";
+        String[] members = new String[]{ "testMember1", "testMember2" };
+        String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
+        Long value = 2L;
+
+        CompletableFuture testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(SAdd), eq(arguments), any()))
+            .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.sadd(key, members);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void srem_returns_success() {
+        // setup
+        String key = "testKey";
+        String[] members = new String[]{ "testMember1", "testMember2" };
+        String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
+        Long value = 2L;
+
+        CompletableFuture testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(SRem), eq(arguments), any()))
+            .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.srem(key, members);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
     }
 }

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -276,7 +276,7 @@ public class RedisClientTest {
     public void sadd_returns_success() {
         // setup
         String key = "testKey";
-        String[] members = new String[]{ "testMember1", "testMember2" };
+        String[] members = new String[] {"testMember1", "testMember2"};
         String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
         Long value = 2L;
 
@@ -285,7 +285,7 @@ public class RedisClientTest {
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(SAdd), eq(arguments), any()))
-            .thenReturn(testResponse);
+                .thenReturn(testResponse);
 
         // exercise
         CompletableFuture<Long> response = service.sadd(key, members);
@@ -301,7 +301,7 @@ public class RedisClientTest {
     public void srem_returns_success() {
         // setup
         String key = "testKey";
-        String[] members = new String[]{ "testMember1", "testMember2" };
+        String[] members = new String[] {"testMember1", "testMember2"};
         String[] arguments = ArrayUtils.addAll(new String[] {key}, members);
         Long value = 2L;
 
@@ -310,7 +310,7 @@ public class RedisClientTest {
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(SRem), eq(arguments), any()))
-            .thenReturn(testResponse);
+                .thenReturn(testResponse);
 
         // exercise
         CompletableFuture<Long> response = service.srem(key, members);

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -7,6 +7,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
@@ -64,6 +66,12 @@ public class ClusterTransactionTests {
 
         transaction.srem("key", "value");
         results.add(Pair.of(SRem, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
+
+        transaction.smembers("key");
+        results.add(Pair.of(SMembers, ArgsArray.newBuilder().addArgs("key").build()));
+
+        transaction.scard("key");
+        results.add(Pair.of(SCard, ArgsArray.newBuilder().addArgs("key").build()));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.models.commands.InfoOptions;
@@ -56,6 +58,12 @@ public class ClusterTransactionTests {
                 Pair.of(
                         Info,
                         ArgsArray.newBuilder().addArgs(InfoOptions.Section.EVERYTHING.toString()).build()));
+
+        transaction.sadd("key", "value");
+        results.add(Pair.of(SAdd, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
+
+        transaction.srem("key", "value");
+        results.add(Pair.of(SRem, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -61,10 +61,10 @@ public class ClusterTransactionTests {
                         Info,
                         ArgsArray.newBuilder().addArgs(InfoOptions.Section.EVERYTHING.toString()).build()));
 
-        transaction.sadd("key", "value");
+        transaction.sadd("key", new String[] {"value"});
         results.add(Pair.of(SAdd, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
 
-        transaction.srem("key", "value");
+        transaction.srem("key", new String[] {"value"});
         results.add(Pair.of(SRem, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
 
         transaction.smembers("key");

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -7,6 +7,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
@@ -63,6 +65,12 @@ public class TransactionTests {
 
         transaction.srem("key", "value");
         results.add(Pair.of(SRem, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
+
+        transaction.smembers("key");
+        results.add(Pair.of(SMembers, ArgsArray.newBuilder().addArgs("key").build()));
+
+        transaction.scard("key");
+        results.add(Pair.of(SCard, ArgsArray.newBuilder().addArgs("key").build()));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -60,10 +60,10 @@ public class TransactionTests {
                         Info,
                         ArgsArray.newBuilder().addArgs(InfoOptions.Section.EVERYTHING.toString()).build()));
 
-        transaction.sadd("key", "value");
+        transaction.sadd("key", new String[] {"value"});
         results.add(Pair.of(SAdd, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
 
-        transaction.srem("key", "value");
+        transaction.srem("key", new String[] {"value"});
         results.add(Pair.of(SRem, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
 
         transaction.smembers("key");

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.models.commands.InfoOptions;
@@ -55,6 +57,12 @@ public class TransactionTests {
                 Pair.of(
                         Info,
                         ArgsArray.newBuilder().addArgs(InfoOptions.Section.EVERYTHING.toString()).build()));
+
+        transaction.sadd("key", "value");
+        results.add(Pair.of(SAdd, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
+
+        transaction.srem("key", "value");
+        results.add(Pair.of(SRem, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -19,6 +19,7 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
 import java.util.List;
+
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -246,5 +247,22 @@ public class SharedCommandTests {
         SetOptions options = SetOptions.builder().returnOldValue(true).build();
         String data = client.set("another", ANOTHER_VALUE, options).get();
         assertNull(data);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void sadd_and_srem(BaseClient client) {
+        String key = KEY_NAME;
+        String member1 = "member1";
+        String member2 = "member2";
+        String[] members = new String[]{ member1, member2 };
+
+        assertEquals(members.length, client.sadd(key, members));
+        assertEquals(0, client.sadd(key, new String[]{member1}));
+
+        assertEquals(0, client.srem(key, new String[]{ "nonexistent_member" }));
+        assertEquals(members.length, client.srem(key, members));
+        assertEquals(0, client.srem(key, members));
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -10,6 +10,7 @@ import static glide.api.models.commands.SetOptions.Expiry.Milliseconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.api.BaseClient;
 import glide.api.RedisClient;
@@ -18,12 +19,12 @@ import glide.api.models.commands.SetOptions;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
-import glide.api.models.exceptions.RedisException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -283,16 +284,28 @@ public class SharedCommandTests {
         String key = UUID.randomUUID().toString();
         assertEquals(OK, client.set(key, "foo").get());
 
-        RedisException e = assertThrows(RedisException.class, () -> client.sadd(key, "bar").get());
-        assertEquals("Operation against a key holding the wrong kind of value", e.getMessage());
+        Exception e = assertThrows(ExecutionException.class, () -> client.sadd(key, "bar").get());
+        assertTrue(
+                e.getCause()
+                        .getMessage()
+                        .contains("Operation against a key holding the wrong kind of value"));
 
-        e = assertThrows(RedisException.class, () -> client.srem(key, "bar").get());
-        assertEquals("Operation against a key holding the wrong kind of value", e.getMessage());
+        e = assertThrows(ExecutionException.class, () -> client.srem(key, "bar").get());
+        assertTrue(
+                e.getCause()
+                        .getMessage()
+                        .contains("Operation against a key holding the wrong kind of value"));
 
-        e = assertThrows(RedisException.class, () -> client.scard(key).get());
-        assertEquals("Operation against a key holding the wrong kind of value", e.getMessage());
+        e = assertThrows(ExecutionException.class, () -> client.scard(key).get());
+        assertTrue(
+                e.getCause()
+                        .getMessage()
+                        .contains("Operation against a key holding the wrong kind of value"));
 
-        e = assertThrows(RedisException.class, () -> client.smembers(key).get());
-        assertEquals("Operation against a key holding the wrong kind of value", e.getMessage());
+        e = assertThrows(ExecutionException.class, () -> client.smembers(key).get());
+        assertTrue(
+                e.getCause()
+                        .getMessage()
+                        .contains("Operation against a key holding the wrong kind of value"));
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -252,7 +252,7 @@ public class SharedCommandTests {
     @ParameterizedTest
     @MethodSource("getClients")
     public void sadd_and_srem(BaseClient client) {
-        String key = KEY_NAME;
+        String key = "sadd_and_srem";
         String member1 = "member1";
         String member2 = "member2";
         String[] members = new String[] {member1, member2};

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -260,7 +260,7 @@ public class SharedCommandTests {
         assertEquals(members.length, client.sadd(key, members).get());
         assertEquals(0, client.sadd(key, new String[] {member1}).get());
 
-        assertEquals(0, client.srem(key, new String[] {"nonexistent_member"}).get());
+        assertEquals(0, client.srem(key, new String[] {"non_existent_member"}).get());
         assertEquals(members.length, client.srem(key, members).get());
         assertEquals(0, client.srem(key, members).get());
     }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -19,7 +19,6 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
 import java.util.List;
-
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -256,12 +255,12 @@ public class SharedCommandTests {
         String key = KEY_NAME;
         String member1 = "member1";
         String member2 = "member2";
-        String[] members = new String[]{ member1, member2 };
+        String[] members = new String[] {member1, member2};
 
         assertEquals(members.length, client.sadd(key, members));
-        assertEquals(0, client.sadd(key, new String[]{member1}));
+        assertEquals(0, client.sadd(key, new String[] {member1}));
 
-        assertEquals(0, client.srem(key, new String[]{ "nonexistent_member" }));
+        assertEquals(0, client.srem(key, new String[] {"nonexistent_member"}));
         assertEquals(members.length, client.srem(key, members));
         assertEquals(0, client.srem(key, members));
     }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -258,22 +258,22 @@ public class SharedCommandTests {
     @MethodSource("getClients")
     public void sadd_srem_scard_smembers_existing_set(BaseClient client) {
         String key = UUID.randomUUID().toString();
-        assertEquals(4, client.sadd(key, "member1", "member2", "member3", "member4"));
-        assertEquals(1, client.srem(key, "member3", "nonExistingMember"));
+        assertEquals(4, client.sadd(key, "member1", "member2", "member3", "member4").get());
+        assertEquals(1, client.srem(key, "member3", "nonExistingMember").get());
 
         Set<String> expectedMembers = new HashSet<>(Arrays.asList("member1", "member2", "member4"));
-        assertEquals(expectedMembers, client.smembers(key));
-        assertEquals(1, client.srem(key, "member1"));
-        assertEquals(2, client.scard(key));
+        assertEquals(expectedMembers, client.smembers(key).get());
+        assertEquals(1, client.srem(key, "member1").get());
+        assertEquals(2, client.scard(key).get());
     }
 
     @SneakyThrows
     @ParameterizedTest
     @MethodSource("getClients")
     public void srem_scard_smembers_non_existing_key(BaseClient client) {
-        assertEquals(0, client.srem("nonExistingKey", "member"));
-        assertEquals(0, client.scard("nonExistingKey"));
-        assertEquals(new HashSet<String>(), client.smembers("nonExistingKey"));
+        assertEquals(0, client.srem("nonExistingKey", "member").get());
+        assertEquals(0, client.scard("nonExistingKey").get());
+        assertEquals(new HashSet<String>(), client.smembers("nonExistingKey").get());
     }
 
     @SneakyThrows
@@ -281,18 +281,18 @@ public class SharedCommandTests {
     @MethodSource("getClients")
     public void sadd_srem_scard_smembers_key_with_non_set_value(BaseClient client) {
         String key = UUID.randomUUID().toString();
-        assertEquals(OK, client.set(key, "foo"));
+        assertEquals(OK, client.set(key, "foo").get());
 
-        RedisException e = assertThrows(RedisException.class, () -> client.sadd(key, "bar"));
+        RedisException e = assertThrows(RedisException.class, () -> client.sadd(key, "bar").get());
         assertEquals("Operation against a key holding the wrong kind of value", e.getMessage());
 
-        e = assertThrows(RedisException.class, () -> client.srem(key, "bar"));
+        e = assertThrows(RedisException.class, () -> client.srem(key, "bar").get());
         assertEquals("Operation against a key holding the wrong kind of value", e.getMessage());
 
-        e = assertThrows(RedisException.class, () -> client.scard(key));
+        e = assertThrows(RedisException.class, () -> client.scard(key).get());
         assertEquals("Operation against a key holding the wrong kind of value", e.getMessage());
 
-        e = assertThrows(RedisException.class, () -> client.smembers(key));
+        e = assertThrows(RedisException.class, () -> client.smembers(key).get());
         assertEquals("Operation against a key holding the wrong kind of value", e.getMessage());
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -258,9 +258,9 @@ public class SharedCommandTests {
         String[] members = new String[] {member1, member2};
 
         assertEquals(members.length, client.sadd(key, members).get());
-        assertEquals(0, client.sadd(key, new String[] {member1}).get());
+        assertEquals(0, client.sadd(key, member1).get());
 
-        assertEquals(0, client.srem(key, new String[] {"non_existent_member"}).get());
+        assertEquals(0, client.srem(key, "non_existent_member").get());
         assertEquals(members.length, client.srem(key, members).get());
         assertEquals(0, client.srem(key, members).get());
     }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -19,8 +19,7 @@ import glide.api.models.commands.SetOptions;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
-import java.util.Arrays;
-import java.util.HashSet;
+import glide.api.models.exceptions.RequestException;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -262,7 +261,7 @@ public class SharedCommandTests {
         assertEquals(4, client.sadd(key, "member1", "member2", "member3", "member4").get());
         assertEquals(1, client.srem(key, "member3", "nonExistingMember").get());
 
-        Set<String> expectedMembers = new HashSet<>(Arrays.asList("member1", "member2", "member4"));
+        Set<String> expectedMembers = Set.of("member1", "member2", "member4");
         assertEquals(expectedMembers, client.smembers(key).get());
         assertEquals(1, client.srem(key, "member1").get());
         assertEquals(2, client.scard(key).get());
@@ -274,7 +273,7 @@ public class SharedCommandTests {
     public void srem_scard_smembers_non_existing_key(BaseClient client) {
         assertEquals(0, client.srem("nonExistingKey", "member").get());
         assertEquals(0, client.scard("nonExistingKey").get());
-        assertEquals(new HashSet<String>(), client.smembers("nonExistingKey").get());
+        assertEquals(Set.of(), client.smembers("nonExistingKey").get());
     }
 
     @SneakyThrows
@@ -285,24 +284,28 @@ public class SharedCommandTests {
         assertEquals(OK, client.set(key, "foo").get());
 
         Exception e = assertThrows(ExecutionException.class, () -> client.sadd(key, "bar").get());
+        assertTrue(e.getCause() instanceof RequestException);
         assertTrue(
                 e.getCause()
                         .getMessage()
                         .contains("Operation against a key holding the wrong kind of value"));
 
         e = assertThrows(ExecutionException.class, () -> client.srem(key, "bar").get());
+        assertTrue(e.getCause() instanceof RequestException);
         assertTrue(
                 e.getCause()
                         .getMessage()
                         .contains("Operation against a key holding the wrong kind of value"));
 
         e = assertThrows(ExecutionException.class, () -> client.scard(key).get());
+        assertTrue(e.getCause() instanceof RequestException);
         assertTrue(
                 e.getCause()
                         .getMessage()
                         .contains("Operation against a key holding the wrong kind of value"));
 
         e = assertThrows(ExecutionException.class, () -> client.smembers(key).get());
+        assertTrue(e.getCause() instanceof RequestException);
         assertTrue(
                 e.getCause()
                         .getMessage()

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -257,11 +257,11 @@ public class SharedCommandTests {
         String member2 = "member2";
         String[] members = new String[] {member1, member2};
 
-        assertEquals(members.length, client.sadd(key, members));
-        assertEquals(0, client.sadd(key, new String[] {member1}));
+        assertEquals(members.length, client.sadd(key, members).get());
+        assertEquals(0, client.sadd(key, new String[] {member1}).get());
 
-        assertEquals(0, client.srem(key, new String[] {"nonexistent_member"}));
-        assertEquals(members.length, client.srem(key, members));
-        assertEquals(0, client.srem(key, members));
+        assertEquals(0, client.srem(key, new String[] {"nonexistent_member"}).get());
+        assertEquals(members.length, client.srem(key, members).get());
+        assertEquals(0, client.srem(key, members).get());
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -285,14 +285,14 @@ public class SharedCommandTests {
         assertEquals(OK, client.set(key, "foo").get());
 
         Exception e =
-                assertThrows(ExecutionException.class, () -> client.sadd(key, new String[] {"bar"}).get());
+                assertThrows(ExecutionException.class, () -> client.sadd(key, new String[] {"baz"}).get());
         assertTrue(e.getCause() instanceof RequestException);
         assertTrue(
                 e.getCause()
                         .getMessage()
                         .contains("Operation against a key holding the wrong kind of value"));
 
-        e = assertThrows(ExecutionException.class, () -> client.srem(key, new String[] {"bar"}).get());
+        e = assertThrows(ExecutionException.class, () -> client.srem(key, new String[] {"baz"}).get());
         assertTrue(e.getCause() instanceof RequestException);
         assertTrue(
                 e.getCause()

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -258,12 +258,13 @@ public class SharedCommandTests {
     @MethodSource("getClients")
     public void sadd_srem_scard_smembers_existing_set(BaseClient client) {
         String key = UUID.randomUUID().toString();
-        assertEquals(4, client.sadd(key, "member1", "member2", "member3", "member4").get());
-        assertEquals(1, client.srem(key, "member3", "nonExistingMember").get());
+        assertEquals(
+                4, client.sadd(key, new String[] {"member1", "member2", "member3", "member4"}).get());
+        assertEquals(1, client.srem(key, new String[] {"member3", "nonExistingMember"}).get());
 
         Set<String> expectedMembers = Set.of("member1", "member2", "member4");
         assertEquals(expectedMembers, client.smembers(key).get());
-        assertEquals(1, client.srem(key, "member1").get());
+        assertEquals(1, client.srem(key, new String[] {"member1"}).get());
         assertEquals(2, client.scard(key).get());
     }
 
@@ -271,7 +272,7 @@ public class SharedCommandTests {
     @ParameterizedTest
     @MethodSource("getClients")
     public void srem_scard_smembers_non_existing_key(BaseClient client) {
-        assertEquals(0, client.srem("nonExistingKey", "member").get());
+        assertEquals(0, client.srem("nonExistingKey", new String[] {"member"}).get());
         assertEquals(0, client.scard("nonExistingKey").get());
         assertEquals(Set.of(), client.smembers("nonExistingKey").get());
     }
@@ -283,14 +284,15 @@ public class SharedCommandTests {
         String key = UUID.randomUUID().toString();
         assertEquals(OK, client.set(key, "foo").get());
 
-        Exception e = assertThrows(ExecutionException.class, () -> client.sadd(key, "bar").get());
+        Exception e =
+                assertThrows(ExecutionException.class, () -> client.sadd(key, new String[] {"bar"}).get());
         assertTrue(e.getCause() instanceof RequestException);
         assertTrue(
                 e.getCause()
                         .getMessage()
                         .contains("Operation against a key holding the wrong kind of value"));
 
-        e = assertThrows(ExecutionException.class, () -> client.srem(key, "bar").get());
+        e = assertThrows(ExecutionException.class, () -> client.srem(key, new String[] {"bar"}).get());
         assertTrue(e.getCause() instanceof RequestException);
         assertTrue(
                 e.getCause()

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -16,8 +16,8 @@ public class TestUtilities {
         baseTransaction.set(key2, value2, SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
 
-        baseTransaction.sadd(key1, new String[]{value1, value2});
-        baseTransaction.srem(key1, new String[]{value1, value2});
+        baseTransaction.sadd(key1, new String[] {value1, value2});
+        baseTransaction.srem(key1, new String[] {value1, value2});
 
         return baseTransaction;
     }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -6,18 +6,18 @@ import glide.api.models.commands.SetOptions;
 import java.util.UUID;
 
 public class TestUtilities {
-    private static final String key1 = "{key}" + UUID.randomUUID();
-    private static final String key2 = "{key}" + UUID.randomUUID();
-    private static final String value1 = "{value}" + UUID.randomUUID();
-    private static final String value2 = "{value}" + UUID.randomUUID();
 
     public static BaseTransaction transactionTest(BaseTransaction baseTransaction) {
-        baseTransaction.set(key1, value1);
-        baseTransaction.set(key2, value2, SetOptions.builder().returnOldValue(true).build());
+        String key1 = "{key}" + UUID.randomUUID();
+        String key2 = "{key}" + UUID.randomUUID();
+
+        baseTransaction.set(key1, "bar");
+        baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
 
-        baseTransaction.sadd(key1, new String[] {value1, value2});
-        baseTransaction.srem(key1, new String[] {value1, value2});
+        String setKey = "set-key";
+        baseTransaction.sadd(setKey, "bar", "baz");
+        baseTransaction.srem(setKey, "bar", "baz");
 
         return baseTransaction;
     }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -23,6 +23,6 @@ public class TestUtilities {
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 2, 2};
+        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 2L, 2L};
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -17,7 +17,7 @@ public class TestUtilities {
         baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
 
-        baseTransaction.sadd(key3, new String[] {"bar", "foo"});
+        baseTransaction.sadd(key3, new String[] {"baz", "foo"});
         baseTransaction.srem(key3, new String[] {"foo"});
         baseTransaction.scard(key3);
         baseTransaction.smembers(key3);
@@ -26,6 +26,6 @@ public class TestUtilities {
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 2L, 1L, 1L, Set.of("bar")};
+        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 2L, 1L, 1L, Set.of("baz")};
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -6,19 +6,23 @@ import glide.api.models.commands.SetOptions;
 import java.util.UUID;
 
 public class TestUtilities {
+    private static final String key1 = "{key}" + UUID.randomUUID();
+    private static final String key2 = "{key}" + UUID.randomUUID();
+    private static final String value1 = "{value}" + UUID.randomUUID();
+    private static final String value2 = "{value}" + UUID.randomUUID();
 
     public static BaseTransaction transactionTest(BaseTransaction baseTransaction) {
-        String key1 = "{key}" + UUID.randomUUID();
-        String key2 = "{key}" + UUID.randomUUID();
-
-        baseTransaction.set(key1, "bar");
-        baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
+        baseTransaction.set(key1, value1);
+        baseTransaction.set(key2, value2, SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
+
+        baseTransaction.sadd(key1, new String[]{value1, value2});
+        baseTransaction.srem(key1, new String[]{value1, value2});
 
         return baseTransaction;
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {"OK", null, new String[] {"bar", "baz"}};
+        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 2, 2};
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -17,8 +17,8 @@ public class TestUtilities {
         baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
 
-        baseTransaction.sadd(key3, "bar", "foo");
-        baseTransaction.srem(key3, "foo");
+        baseTransaction.sadd(key3, new String[] {"bar", "foo"});
+        baseTransaction.srem(key3, new String[] {"foo"});
         baseTransaction.scard(key3);
         baseTransaction.smembers(key3);
 

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -3,6 +3,8 @@ package glide;
 
 import glide.api.models.BaseTransaction;
 import glide.api.models.commands.SetOptions;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.UUID;
 
 public class TestUtilities {
@@ -10,19 +12,23 @@ public class TestUtilities {
     public static BaseTransaction transactionTest(BaseTransaction baseTransaction) {
         String key1 = "{key}" + UUID.randomUUID();
         String key2 = "{key}" + UUID.randomUUID();
+        String key3 = "{key}" + UUID.randomUUID();
 
         baseTransaction.set(key1, "bar");
         baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
 
-        String setKey = "set-key";
-        baseTransaction.sadd(setKey, "bar", "baz");
-        baseTransaction.srem(setKey, "bar", "baz");
+        baseTransaction.sadd(key3, "bar", "foo");
+        baseTransaction.srem(key3, "foo");
+        baseTransaction.scard(key3);
+        baseTransaction.smembers(key3);
 
         return baseTransaction;
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 2L, 2L};
+        return new Object[] {
+            "OK", null, new String[] {"bar", "baz"}, 2L, 1L, 1L, new HashSet<>(Arrays.asList("bar"))
+        };
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -3,8 +3,7 @@ package glide;
 
 import glide.api.models.BaseTransaction;
 import glide.api.models.commands.SetOptions;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 public class TestUtilities {
@@ -27,8 +26,6 @@ public class TestUtilities {
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {
-            "OK", null, new String[] {"bar", "baz"}, 2L, 1L, 1L, new HashSet<>(Arrays.asList("bar"))
-        };
+        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 2L, 1L, 1L, Set.of("bar")};
     }
 }


### PR DESCRIPTION
Adds initial set commands: `sadd`, `srem`, `smembers`, and `scard`.

Examples:
```java
Long saddResult = client.sadd("key", "member1", "member2", "member3", "member4").get();
assert saddResult == 4;
Long sremResult = client.srem("key", "member3").get();
assert sremResult == 1;
Set<String> smembersResult = client.smembers("key").get();
assert smembersResult.equals(Set.of("member1", "member2", "member4"));
Long scardResult = client.scard("key").get();
assert scardResult == 3;
```