### PR TITLE
Java: Add UNLINK() command

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -5,8 +5,10 @@ import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.commands.ConnectionManagementCommands;
+import glide.api.commands.GenericBaseCommands;
 import glide.api.commands.StringCommands;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.configuration.BaseClientConfiguration;
@@ -32,7 +34,7 @@ import response.ResponseOuterClass.Response;
 /** Base Client class for Redis */
 @AllArgsConstructor
 public abstract class BaseClient
-        implements AutoCloseable, ConnectionManagementCommands, StringCommands {
+        implements AutoCloseable, GenericBaseCommands, ConnectionManagementCommands, StringCommands {
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
 
@@ -149,6 +151,10 @@ public abstract class BaseClient
         return handleRedisResponse(String.class, true, response);
     }
 
+    protected Long handleLongResponse(Response response) throws RedisException {
+        return handleRedisResponse(Long.class, false, response);
+    }
+
     protected Object[] handleArrayResponse(Response response) {
         return handleRedisResponse(Object[].class, true, response);
     }
@@ -180,5 +186,10 @@ public abstract class BaseClient
             @NonNull String key, @NonNull String value, @NonNull SetOptions options) {
         String[] arguments = ArrayUtils.addAll(new String[] {key, value}, options.toArgs());
         return commandManager.submitNewCommand(SetString, arguments, this::handleStringOrNullResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> unlink(@NonNull String[] keys) {
+        return commandManager.submitNewCommand(Unlink, keys, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -16,7 +16,7 @@ public interface GenericBaseCommands {
      * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
      *
      * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
-     * @param keys - The <code>keys</code> we wanted to unlink.
+     * @param keys The <code>keys</code> we wanted to unlink.
      * @return the number of <code>keys</code> that were unlinked.
      */
     CompletableFuture<Long> unlink(String[] keys);

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -1,0 +1,23 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generic Commands interface to handle generic commands for all server requests.
+ *
+ * @see <a href="https://redis.io/commands/?group=generic">Generic Commands</a>
+ */
+public interface GenericBaseCommands {
+
+    /**
+     * Removes the specified <code>keys</code>. A key is ignored if it does not exist. This command,
+     * similar to DEL, removes specified keys and ignores non-existent ones. However, this command
+     * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
+     *
+     * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
+     * @param keys - The <code>keys</code> we wanted to unlink.
+     * @return the number of <code>keys</code> that were unlinked.
+     */
+    CompletableFuture<Long> unlink(String[] keys);
+}

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -121,7 +121,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
      *
      * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
-     * @param keys The <code>keys</code> we wanted to unlink.
+     * @param keys  The <code>keys</code> we wanted to unlink.
      * @return the number of <code>keys</code> that were unlinked.
      */
     public T unlink(String[] keys) {

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -92,8 +92,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Section#DEFAULT} option is assumed.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
-     * @apiNote Command Response - a <code>String</code> containing the information for the sections
-     *     requested.
+     * @return A response from Redis with a <code>String</code>.
      */
     public T info() {
         protobufTransaction.addCommands(buildCommand(Info));
@@ -122,7 +121,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
      *
      * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
-     * @param keys - The <code>keys</code> we wanted to unlink.
+     * @param keys The <code>keys</code> we wanted to unlink.
      * @return the number of <code>keys</code> that were unlinked.
      */
     public T unlink(String[] keys) {

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -6,6 +6,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.InfoOptions.Section;
@@ -91,7 +92,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Section#DEFAULT} option is assumed.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
-     * @return A response from Redis with a <code>String</code>.
+     * @apiNote Command Response - a <code>String</code> containing the information for the sections
+     *     requested.
      */
     public T info() {
         protobufTransaction.addCommands(buildCommand(Info));
@@ -111,6 +113,22 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
         ArgsArray commandArgs = buildArgs(options.toArgs());
 
         protobufTransaction.addCommands(buildCommand(Info, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Removes the specified <code>keys</code>. A key is ignored if it does not exist. This command,
+     * similar to DEL, removes specified keys and ignores non-existent ones. However, this command
+     * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
+     *
+     * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
+     * @param keys - The <code>keys</code> we wanted to unlink.
+     * @return the number of <code>keys</code> that were unlinked.
+     */
+    public T unlink(String[] keys) {
+        ArgsArray commandArgs = buildArgs(keys);
+
+        protobufTransaction.addCommands(buildCommand(Unlink, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -121,7 +121,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
      *
      * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
-     * @param keys  The <code>keys</code> we wanted to unlink.
+     * @param keys The <code>keys</code> we wanted to unlink.
      * @return the number of <code>keys</code> that were unlinked.
      */
     public T unlink(String[] keys) {

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -16,6 +16,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.SetOptions;
@@ -106,6 +107,26 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(message, pong);
+    }
+
+    @SneakyThrows
+    @Test
+    public void unlink_returns_long_success() {
+        // setup
+        String[] keys = new String[] {"testKey1", "testKey2"};
+        Long numberUnlinked = 1L;
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(numberUnlinked);
+        when(commandManager.<Long>submitNewCommand(eq(Unlink), eq(keys), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.unlink(keys);
+        Long result = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(numberUnlinked, result);
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -7,6 +7,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.SetOptions;
@@ -41,6 +42,9 @@ public class ClusterTransactionTests {
                                 .addArgs("value")
                                 .addArgs(RETURN_OLD_VALUE)
                                 .build()));
+
+        transaction.unlink(new String[] {"key1", "key2"});
+        results.add(Pair.of(Unlink, ArgsArray.newBuilder().addArgs("key1").addArgs("key2").build()));
 
         transaction.ping();
         results.add(Pair.of(Ping, ArgsArray.newBuilder().build()));

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -7,6 +7,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.SetOptions;
@@ -40,6 +41,9 @@ public class TransactionTests {
                                 .addArgs("value")
                                 .addArgs(RETURN_OLD_VALUE)
                                 .build()));
+
+        transaction.unlink(new String[] {"key1", "key2"});
+        results.add(Pair.of(Unlink, ArgsArray.newBuilder().addArgs("key1").addArgs("key2").build()));
 
         transaction.ping();
         results.add(Pair.of(Ping, ArgsArray.newBuilder().build()));

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -19,6 +19,7 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
 import java.util.List;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -82,6 +83,34 @@ public class SharedCommandTests {
     public void ping_with_message(BaseClient client) {
         String data = client.ping("H3LL0").get();
         assertEquals("H3LL0", data);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void unlink_multiple_keys(BaseClient client) {
+        String key1 = "{key}" + UUID.randomUUID();
+        String key2 = "{key}" + UUID.randomUUID();
+        String key3 = "{key}" + UUID.randomUUID();
+        String value = UUID.randomUUID().toString();
+
+        String setResult = client.set(key1, value).get();
+        assertEquals(OK, setResult);
+        setResult = client.set(key2, value).get();
+        assertEquals(OK, setResult);
+        setResult = client.set(key3, value).get();
+        assertEquals(OK, setResult);
+
+        Long unlinkedKeysNum = client.unlink(new String[] {key1, key2, key3}).get();
+        assertEquals(3L, unlinkedKeysNum);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void unlink_non_existent_key(BaseClient client) {
+        Long unlinkedKeysNum = client.unlink(new String[] {UUID.randomUUID().toString()}).get();
+        assertEquals(0L, unlinkedKeysNum);
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -14,11 +14,12 @@ public class TestUtilities {
         baseTransaction.set(key1, "bar");
         baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
+        baseTransaction.unlink(new String[] {key1});
 
         return baseTransaction;
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {"OK", null, new String[] {"bar", "baz"}};
+        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 1L};
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding the UNLINK() command (Generic command).  Note, unlink() and del() are very similar commands. 

Example: 
```
// assuming key1 and key2 exist, while key "invalid" does not. 
Integer result = client.unlink(new String[] {"key1", "key2", "invalid"}).get();
assert result == 2;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
