### PR TITLE
Add `CONFIG REWRITE` and `CONFIG RESETSTAT`.

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -4,6 +4,8 @@ package glide.api;
 import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
 import static glide.utils.ArrayTransformUtils.castArray;
 import static glide.utils.ArrayTransformUtils.convertMapToArgArray;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigResetStat;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
@@ -24,6 +26,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.commands.ConnectionManagementCommands;
 import glide.api.commands.HashCommands;
+import glide.api.commands.ServerManagementBaseCommands;
 import glide.api.commands.SetCommands;
 import glide.api.commands.StringCommands;
 import glide.api.models.commands.SetOptions;
@@ -56,7 +59,8 @@ public abstract class BaseClient
                 ConnectionManagementCommands,
                 StringCommands,
                 HashCommands,
-                SetCommands {
+                SetCommands,
+                ServerManagementBaseCommands {
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
 
@@ -308,5 +312,17 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<Long> scard(String key) {
         return commandManager.submitNewCommand(SCard, new String[] {key}, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> configRewrite() {
+        return commandManager.submitNewCommand(
+                ConfigRewrite, new String[0], this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> configResetStat() {
+        return commandManager.submitNewCommand(
+                ConfigResetStat, new String[0], this::handleStringResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -1,6 +1,8 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigResetStat;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
@@ -131,5 +133,27 @@ public class RedisClusterClient extends BaseClient
                         route.isSingleNodeRoute()
                                 ? ClusterValue.of(handleStringResponse(response))
                                 : ClusterValue.of(handleMapResponse(response)));
+    }
+
+    @Override
+    public CompletableFuture<String> configRewrite() {
+        return super.configRewrite();
+    }
+
+    @Override
+    public CompletableFuture<String> configResetStat() {
+        return super.configResetStat();
+    }
+
+    @Override
+    public CompletableFuture<String> configRewrite(@NonNull Route route) {
+        return commandManager.submitNewCommand(
+                ConfigRewrite, new String[0], route, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> configResetStat(@NonNull Route route) {
+        return commandManager.submitNewCommand(
+                ConfigResetStat, new String[0], route, this::handleStringResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -141,14 +141,14 @@ public class RedisClusterClient extends BaseClient
     }
 
     @Override
-    public CompletableFuture<String> configResetStat() {
-        return super.configResetStat();
-    }
-
-    @Override
     public CompletableFuture<String> configRewrite(@NonNull Route route) {
         return commandManager.submitNewCommand(
                 ConfigRewrite, new String[0], route, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> configResetStat() {
+        return super.configResetStat();
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/ServerManagementBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementBaseCommands.java
@@ -16,15 +16,26 @@ public interface ServerManagementBaseCommands {
      * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
      * @return <code>OK</code> when the configuration was rewritten properly, otherwise an error is
      *     raised.
+     * @example
+     *     <pre>
+     * String response = client.configRewrite().get();
+     * assert response.equals("OK")
+     * </pre>
      */
     CompletableFuture<String> configRewrite();
 
     /**
-     * Reset the statistics reported by Redis using the <code>INFO</code> and <code>LATENCY HISTOGRAM
-     * </code> commands.
+     * Reset the statistics reported by Redis using the <a
+     * href="https://redis.io/commands/info/">INFO</a> and <a
+     * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM </a> commands.
      *
      * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
      * @return <code>OK</code> to confirm that the statistics were successfully reset.
+     * @example
+     *     <pre>
+     * String response = client.configResetStat().get();
+     * assert response.equals("OK")
+     * </pre>
      */
     CompletableFuture<String> configResetStat();
 }

--- a/java/client/src/main/java/glide/api/commands/ServerManagementBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementBaseCommands.java
@@ -1,0 +1,30 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Server Management Commands interface for both standalone and cluster clients.
+ *
+ * @see <a href="https://redis.io/commands/?group=server">Server Management Commands</a>
+ */
+public interface ServerManagementBaseCommands {
+
+    /**
+     * Rewrite the configuration file with the current configuration.
+     *
+     * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
+     * @return <code>OK</code> when the configuration was rewritten properly, otherwise an error is
+     *     raised.
+     */
+    CompletableFuture<String> configRewrite();
+
+    /**
+     * Reset the statistics reported by Redis using the <code>INFO</code> and <code>LATENCY HISTOGRAM
+     * </code> commands.
+     *
+     * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
+     * @return <code>OK</code> to confirm that the statistics were successfully reset.
+     */
+    CompletableFuture<String> configResetStat();
+}

--- a/java/client/src/main/java/glide/api/commands/ServerManagementBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementBaseCommands.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture;
 public interface ServerManagementBaseCommands {
 
     /**
-     * Rewrite the configuration file with the current configuration.
+     * Rewrites the configuration file with the current configuration.
      *
      * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
      * @return <code>OK</code> when the configuration was rewritten properly, otherwise an error is
@@ -25,9 +25,9 @@ public interface ServerManagementBaseCommands {
     CompletableFuture<String> configRewrite();
 
     /**
-     * Reset the statistics reported by Redis using the <a
+     * Resets the statistics reported by Redis using the <a
      * href="https://redis.io/commands/info/">INFO</a> and <a
-     * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM </a> commands.
+     * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM</a> commands.
      *
      * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
      * @return <code>OK</code> to confirm that the statistics were successfully reset.

--- a/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
@@ -73,7 +73,7 @@ public interface ServerManagementClusterCommands {
     CompletableFuture<ClusterValue<String>> info(InfoOptions options, Route route);
 
     /**
-     * Rewrite the configuration file with the current configuration.<br>
+     * Rewrites the configuration file with the current configuration.<br>
      * The command will be routed automatically to all nodes.
      *
      * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
@@ -88,23 +88,7 @@ public interface ServerManagementClusterCommands {
     CompletableFuture<String> configRewrite();
 
     /**
-     * Reset the statistics reported by Redis using the <a
-     * href="https://redis.io/commands/info/">INFO</a> and <a
-     * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM </a> commands.<br>
-     * The command will be routed automatically to all nodes.
-     *
-     * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
-     * @return <code>OK</code> to confirm that the statistics were successfully reset.
-     * @example
-     *     <pre>
-     * String response = client.configResetStat().get();
-     * assert response.equals("OK")
-     * </pre>
-     */
-    CompletableFuture<String> configResetStat();
-
-    /**
-     * Rewrite the configuration file with the current configuration.
+     * Rewrites the configuration file with the current configuration.
      *
      * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
      * @param route Routing configuration for the command. Client will route the command to the nodes
@@ -120,7 +104,23 @@ public interface ServerManagementClusterCommands {
     CompletableFuture<String> configRewrite(Route route);
 
     /**
-     * Reset the statistics reported by Redis using the <a
+     * Resets the statistics reported by Redis using the <a
+     * href="https://redis.io/commands/info/">INFO</a> and <a
+     * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM </a> commands.<br>
+     * The command will be routed automatically to all nodes.
+     *
+     * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
+     * @return <code>OK</code> to confirm that the statistics were successfully reset.
+     * @example
+     *     <pre>
+     * String response = client.configResetStat().get();
+     * assert response.equals("OK")
+     * </pre>
+     */
+    CompletableFuture<String> configResetStat();
+
+    /**
+     * Resets the statistics reported by Redis using the <a
      * href="https://redis.io/commands/info/">INFO</a> and <a
      * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM </a> commands.
      *

--- a/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
@@ -73,20 +73,33 @@ public interface ServerManagementClusterCommands {
     CompletableFuture<ClusterValue<String>> info(InfoOptions options, Route route);
 
     /**
-     * Rewrite the configuration file with the current configuration.
+     * Rewrite the configuration file with the current configuration.<br>
+     * The command will be routed automatically to all nodes.
      *
      * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
      * @return <code>OK</code> when the configuration was rewritten properly, otherwise an error is
      *     raised.
+     * @example
+     *     <pre>
+     * String response = client.configRewrite().get();
+     * assert response.equals("OK")
+     * </pre>
      */
     CompletableFuture<String> configRewrite();
 
     /**
-     * Reset the statistics reported by Redis using the <code>INFO</code> and <code>LATENCY HISTOGRAM
-     * </code> commands.
+     * Reset the statistics reported by Redis using the <a
+     * href="https://redis.io/commands/info/">INFO</a> and <a
+     * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM </a> commands.<br>
+     * The command will be routed automatically to all nodes.
      *
      * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
      * @return <code>OK</code> to confirm that the statistics were successfully reset.
+     * @example
+     *     <pre>
+     * String response = client.configResetStat().get();
+     * assert response.equals("OK")
+     * </pre>
      */
     CompletableFuture<String> configResetStat();
 
@@ -98,17 +111,28 @@ public interface ServerManagementClusterCommands {
      *     defined.
      * @return <code>OK</code> when the configuration was rewritten properly, otherwise an error is
      *     raised.
+     * @example
+     *     <pre>
+     * String response = client.configRewrite(ALL_PRIMARIES).get();
+     * assert response.equals("OK")
+     * </pre>
      */
     CompletableFuture<String> configRewrite(Route route);
 
     /**
-     * Resets the statistics reported by Redis using the <code>INFO</code> and <code>LATENCY HISTOGRAM
-     * </code> commands.
+     * Reset the statistics reported by Redis using the <a
+     * href="https://redis.io/commands/info/">INFO</a> and <a
+     * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM </a> commands.
      *
      * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
      * @param route Routing configuration for the command. Client will route the command to the nodes
      *     defined.
      * @return <code>OK</code> to confirm that the statistics were successfully reset.
+     * @example
+     *     <pre>
+     * String response = client.configResetStat(ALL_PRIMARIES).get();
+     * assert response.equals("OK")
+     * </pre>
      */
     CompletableFuture<String> configResetStat(Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
@@ -8,7 +8,7 @@ import glide.api.models.configuration.RequestRoutingConfiguration.Route;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Server Management Commands interface.
+ * Server Management Commands interface for cluster client.
  *
  * @see <a href="https://redis.io/commands/?group=server">Server Management Commands</a>
  */
@@ -71,4 +71,44 @@ public interface ServerManagementClusterCommands {
      *     value is the information of the sections requested for the node.
      */
     CompletableFuture<ClusterValue<String>> info(InfoOptions options, Route route);
+
+    /**
+     * Rewrite the configuration file with the current configuration.
+     *
+     * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
+     * @return <code>OK</code> when the configuration was rewritten properly, otherwise an error is
+     *     raised.
+     */
+    CompletableFuture<String> configRewrite();
+
+    /**
+     * Reset the statistics reported by Redis using the <code>INFO</code> and <code>LATENCY HISTOGRAM
+     * </code> commands.
+     *
+     * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
+     * @return <code>OK</code> to confirm that the statistics were successfully reset.
+     */
+    CompletableFuture<String> configResetStat();
+
+    /**
+     * Rewrite the configuration file with the current configuration.
+     *
+     * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
+     * @param route Routing configuration for the command. Client will route the command to the nodes
+     *     defined.
+     * @return <code>OK</code> when the configuration was rewritten properly, otherwise an error is
+     *     raised.
+     */
+    CompletableFuture<String> configRewrite(Route route);
+
+    /**
+     * Resets the statistics reported by Redis using the <code>INFO</code> and <code>LATENCY HISTOGRAM
+     * </code> commands.
+     *
+     * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
+     * @param route Routing configuration for the command. Client will route the command to the nodes
+     *     defined.
+     * @return <code>OK</code> to confirm that the statistics were successfully reset.
+     */
+    CompletableFuture<String> configResetStat(Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ServerManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementCommands.java
@@ -6,7 +6,7 @@ import glide.api.models.commands.InfoOptions.Section;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Server Management Commands interface.
+ * Server Management Commands interface for standalone client.
  *
  * @see <a href="https://redis.io/commands/?group=server">Server Management Commands</a>
  */

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -2,6 +2,8 @@
 package glide.api.models;
 
 import static glide.utils.ArrayTransformUtils.convertMapToArgArray;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigResetStat;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
@@ -410,6 +412,30 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
         ArgsArray commandArgs = buildArgs(key);
 
         protobufTransaction.addCommands(buildCommand(SCard, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Rewrite the configuration file with the current configuration.
+     *
+     * @see <a href="https://redis.io/commands/config-rewrite/">redis.io</a> for details.
+     * @return <code>OK</code> when the configuration was rewritten properly, otherwise an error is
+     *     raised.
+     */
+    public T configRewrite() {
+        protobufTransaction.addCommands(buildCommand(ConfigRewrite));
+        return getThis();
+    }
+
+    /**
+     * Reset the statistics reported by Redis using the <code>INFO</code> and <code>LATENCY HISTOGRAM
+     * </code> commands.
+     *
+     * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
+     * @return <code>OK</code> to confirm that the statistics were successfully reset.
+     */
+    public T configResetStat() {
+        protobufTransaction.addCommands(buildCommand(ConfigResetStat));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -428,8 +428,9 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Reset the statistics reported by Redis using the <code>INFO</code> and <code>LATENCY HISTOGRAM
-     * </code> commands.
+     * Reset the statistics reported by Redis using the <a
+     * href="https://redis.io/commands/info/">INFO</a> and <a
+     * href="https://redis.io/commands/latency-histogram/">LATENCY HISTOGRAM </a> commands.
      *
      * @see <a href="https://redis.io/commands/config-resetstat/">redis.io</a> for details.
      * @return <code>OK</code> to confirm that the statistics were successfully reset.

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -43,16 +43,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
-import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import redis_request.RedisRequestOuterClass.RequestType;
 
 public class RedisClientTest {
 
@@ -91,6 +85,26 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void ping_returns_success() {
+        // setup
+        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn("PONG");
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(Ping), eq(new String[0]), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.ping();
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals("PONG", payload);
     }
 
     @SneakyThrows
@@ -213,6 +227,25 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void info_returns_success() {
+        // setup
+        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+        String testPayload = "Key: Value";
+        when(testResponse.get()).thenReturn(testPayload);
+        when(commandManager.<String>submitNewCommand(eq(Info), eq(new String[0]), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.info();
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(testPayload, payload);
+    }
+
+    @SneakyThrows
+    @Test
     public void info_with_multiple_InfoOptions_returns_success() {
         // setup
         String[] arguments =
@@ -297,37 +330,6 @@ public class RedisClientTest {
 
         // exercise
         CompletableFuture<String> response = service.mset(keyValueMap);
-    }
-
-    private static Stream<Arguments> getCommandsWithoutArgs() {
-        return Map.<RequestType, Function<RedisClient, CompletableFuture<String>>>of(
-                        ConfigRewrite, RedisClient::configRewrite,
-                        ConfigResetStat, RedisClient::configResetStat,
-                        Info, RedisClient::info,
-                        Ping, RedisClient::ping)
-                .entrySet()
-                .stream()
-                .map(e -> Arguments.of(e.getKey(), e.getValue()));
-    }
-
-    @SneakyThrows
-    @ParameterizedTest(name = "{0} returns success")
-    @MethodSource("getCommandsWithoutArgs")
-    public void no_arg_command_returns_success(
-            RequestType requestType, Function<RedisClient, CompletableFuture<String>> command) {
-        // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
-        when(commandManager.<String>submitNewCommand(eq(requestType), eq(new String[0]), any()))
-                .thenReturn(testResponse);
-
-        // exercise
-        CompletableFuture<String> response = command.apply(service);
-        String payload = response.get();
-
-        // verify
-        assertEquals(testResponse, response);
-        assertEquals(OK, payload);
     }
 
     @SneakyThrows
@@ -616,5 +618,41 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void configRewrite_returns_success() {
+        // setup
+        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(OK);
+        when(commandManager.<String>submitNewCommand(eq(ConfigRewrite), eq(new String[0]), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.configRewrite();
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(OK, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void configResetStat_returns_success() {
+        // setup
+        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(OK);
+        when(commandManager.<String>submitNewCommand(eq(ConfigResetStat), eq(new String[0]), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.configResetStat();
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(OK, payload);
     }
 }

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -3,6 +3,8 @@ package glide.api.models;
 
 import static glide.api.models.commands.SetOptions.RETURN_OLD_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigResetStat;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
@@ -116,6 +118,10 @@ public class ClusterTransactionTests {
 
         transaction.scard("key");
         results.add(Pair.of(SCard, ArgsArray.newBuilder().addArgs("key").build()));
+
+        transaction.configRewrite().configResetStat();
+        results.add(Pair.of(ConfigRewrite, ArgsArray.newBuilder().build()));
+        results.add(Pair.of(ConfigResetStat, ArgsArray.newBuilder().build()));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -3,6 +3,8 @@ package glide.api.models;
 
 import static glide.api.models.commands.SetOptions.RETURN_OLD_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigResetStat;
+import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
@@ -115,6 +117,10 @@ public class TransactionTests {
 
         transaction.scard("key");
         results.add(Pair.of(SCard, ArgsArray.newBuilder().addArgs("key").build()));
+
+        transaction.configRewrite().configResetStat();
+        results.add(Pair.of(ConfigRewrite, ArgsArray.newBuilder().build()));
+        results.add(Pair.of(ConfigResetStat, ArgsArray.newBuilder().build()));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -440,4 +440,12 @@ public class SharedCommandTests {
         e = assertThrows(ExecutionException.class, () -> client.smembers(key).get());
         assertTrue(e.getCause() instanceof RequestException);
     }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void config_reset_stat(BaseClient client) {
+        String ok = client.configResetStat().get();
+        assertEquals(OK, ok);
+    }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -1,0 +1,26 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import glide.api.models.ClusterValue;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TestUtilities {
+    /** Extract integer parameter value from INFO command output */
+    public static int getValueFromInfo(String data, String value) {
+        for (var line : data.split("\r\n")) {
+            if (line.contains(value)) {
+                return Integer.parseInt(line.split(":")[1]);
+            }
+        }
+        fail();
+        return 0;
+    }
+
+    /** Extract first value from {@link ClusterValue} assuming it contains a multi-value. */
+    public static <T> T getFirstEntryFromMultiValue(ClusterValue<T> data) {
+        return data.getMultiValue().get(data.getMultiValue().keySet().toArray(String[]::new)[0]);
+    }
+}

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -1,6 +1,8 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide;
 
+import static glide.api.BaseClient.OK;
+
 import glide.api.models.BaseTransaction;
 import glide.api.models.commands.SetOptions;
 import java.util.Map;
@@ -46,16 +48,18 @@ public class TransactionTestUtilities {
         baseTransaction.scard(key5);
         baseTransaction.smembers(key5);
 
+        baseTransaction.configResetStat();
+
         return baseTransaction;
     }
 
     public static Object[] transactionTestResult() {
         return new Object[] {
-            "OK",
+            OK,
             value1,
             null,
             new String[] {value1, value2},
-            "OK",
+            OK,
             new String[] {value2, value1},
             1L,
             3L,
@@ -69,6 +73,7 @@ public class TransactionTestUtilities {
             1L,
             1L,
             Set.of("baz"),
+            OK
         };
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -3,10 +3,13 @@ package glide.standalone;
 
 import static glide.TestConfiguration.REDIS_VERSION;
 import static glide.TestConfiguration.STANDALONE_PORTS;
+import static glide.TestUtilities.getValueFromInfo;
+import static glide.api.BaseClient.OK;
 import static glide.api.models.commands.InfoOptions.Section.CLUSTER;
 import static glide.api.models.commands.InfoOptions.Section.CPU;
 import static glide.api.models.commands.InfoOptions.Section.EVERYTHING;
 import static glide.api.models.commands.InfoOptions.Section.MEMORY;
+import static glide.api.models.commands.InfoOptions.Section.STATS;
 import static glide.cluster.CommandTests.DEFAULT_INFO_SECTIONS;
 import static glide.cluster.CommandTests.EVERYTHING_INFO_SECTIONS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -98,5 +101,19 @@ public class CommandTests {
         for (String section : EVERYTHING_INFO_SECTIONS) {
             assertTrue(data.contains("# " + section), "Section " + section + " is missing");
         }
+    }
+
+    @Test
+    @SneakyThrows
+    public void config_reset_stat() {
+        String data = regularClient.info(InfoOptions.builder().section(STATS).build()).get();
+        int value_before = getValueFromInfo(data, "total_net_input_bytes");
+
+        var result = regularClient.configResetStat().get();
+        assertEquals(OK, result);
+
+        data = regularClient.info(InfoOptions.builder().section(STATS).build()).get();
+        int value_after = getValueFromInfo(data, "total_net_input_bytes");
+        assertTrue(value_after < value_before);
     }
 }


### PR DESCRIPTION
Features:
* `CONFIG REWRITE` https://redis.io/commands/config-rewrite/
* `CONFIG RESETSTAT` https://redis.io/commands/config-resetstat/
* UT consolidation for standalone and cluster client
* no IT for `CONFIG REWRITE`, because redis in IT runs without config file