### PR TITLE
Remove cancellation when new commits are detected for Go and Java CI workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,11 +16,6 @@ on:
             - go/**
             - .github/workflows/go.yml
 
-# Run only the latest job on a branch and cancel previous ones
-concurrency:
-    group: ${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
-
 jobs:
     build-and-test-go-client:
         timeout-minutes: 20

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -15,11 +15,6 @@ on:
             - "java/**"
             - ".github/workflows/java.yml"
 
-# Run only most latest job on a branch and cancel previous ones
-concurrency:
-    group: ${{ github.head_ref || github.ref }}
-    cancel-in-progress: true
-
 jobs:
     build-and-test-java-client:
         timeout-minutes: 25


### PR DESCRIPTION
This PR removes the cancellation of workflows for Java and Golang when updates are pushed to a branch. It seems that there may be a race condition where the latest updates to a branch should win the race and not cause the workflow to be cancelled, but doesn't (a similar issue is posted at the bottom of this thread https://github.com/orgs/community/discussions/13496).