### PR TITLE
Configure concurrency for all CI.

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -18,6 +18,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+    group: C#-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     run-tests:
         timeout-minutes: 15

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,11 @@ on:
             - go/**
             - .github/workflows/go.yml
 
+concurrency:
+    group: go-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
+
 jobs:
     build-and-test-go-client:
         timeout-minutes: 20

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -15,6 +15,10 @@ on:
             - "java/**"
             - ".github/workflows/java.yml"
 
+concurrency:
+    group: java-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     build-and-test-java-client:
         timeout-minutes: 25

--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -14,6 +14,10 @@ on:
             - benchmarks/utilities/*
             - .github/workflows/lint-ts.yml
 
+concurrency:
+    group: node-lint-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 env:
     CARGO_TERM_COLOR: always
 jobs:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -21,6 +21,10 @@ on:
             - .github/workflows/build-node-wrapper/action.yml
             - .github/workflows/install-shared-dependencies/action.yml
 
+concurrency:
+    group: node-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 env:
     CARGO_TERM_COLOR: always
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,9 @@ on:
             - .github/workflows/install-shared-dependencies/action.yml
             - .github/workflows/install-redis-modules/action.yml
 
+concurrency:
+    group: python-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
 permissions:
     contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,10 @@ on:
             - utils/cluster_manager.py
             - .github/workflows/rust.yml
 
+concurrency:
+    group: rust-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
 env:
     CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Restore CI concurrency removed in #991.
To avoid conflicts between different CI workflows, every group name contains the wrapper name.
The purpose of this to cancel CI for a branch if it got a new commits (so new CI started).

Docs:
https://docs.github.com/en/actions/learn-github-actions/contexts
https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
