### PR TITLE
Java: Update benchmarking to use CachedThreadPool 

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -196,7 +196,7 @@ do
         -lettuce)
             runAllBenchmarks=0
             runJava=1
-            chosenClients="lettuce_async"
+            chosenClients="lettuce"
             ;;
         -jedis)
             runAllBenchmarks=0

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
@@ -27,7 +27,7 @@ public class Benchmarking {
     static final int SIZE_SET_KEYSPACE = 3000000;
     public static final double NANO_TO_SECONDS = 1e9;
 
-    static final int NUM_OF_THREADS_TO_EXECUTE = 8;
+    static final int NUM_OF_THREADS_TO_EXECUTE = 12;
 
     private static ChosenAction randomAction() {
         if (Math.random() > PROB_GET) {

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
@@ -29,8 +29,6 @@ public class Benchmarking {
     static final int SIZE_SET_KEYSPACE = 3000000;
     public static final double NANO_TO_SECONDS = 1e9;
 
-    static final int NUM_OF_THREADS_TO_EXECUTE = 12;
-
     private static ChosenAction randomAction() {
         if (Math.random() > PROB_GET) {
             return ChosenAction.SET;

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
@@ -112,7 +112,7 @@ public class Benchmarking {
     public static void testClientSetGet(
             Supplier<Client> clientCreator, BenchmarkingApp.RunConfiguration config, boolean async) {
         for (int concurrentNum : config.concurrentTasks) {
-            ExecutorService executor = Executors.newFixedThreadPool(NUM_OF_THREADS_TO_EXECUTE);
+            ExecutorService executor = Executors.newCachedThreadPool();
             int iterations =
                     config.minimal ? 1000 : Math.min(Math.max(100000, concurrentNum * 10000), 10000000);
             for (int clientCount : config.clientCount) {

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
@@ -27,7 +27,7 @@ public class Benchmarking {
     static final int SIZE_SET_KEYSPACE = 3000000;
     public static final double NANO_TO_SECONDS = 1e9;
 
-    static final int NUM_OF_THREADS_TO_EXECUTE = 4;
+    static final int NUM_OF_THREADS_TO_EXECUTE = 8;
 
     private static ChosenAction randomAction() {
         if (Math.random() > PROB_GET) {


### PR DESCRIPTION
See benchmarking results in: https://github.com/aws/glide-for-redis/issues/691#issuecomment-1980111310

replaces: https://github.com/aws/glide-for-redis/issues/691