### PR TITLE
Go: miscellaneous CI improvements

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
     build-and-test-go-client:
-        timeout-minutes: 20
+        timeout-minutes: 45
         strategy:
             # Run all jobs
             fail-fast: false
@@ -68,6 +68,10 @@ jobs:
               working-directory: ./go
               run: make install-tools-go${{ matrix.go }}
 
+            - name: Set LD_LIBRARY_PATH
+              if: ${{ matrix.os == 'ubuntu-latest' }}
+              run: echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/go/target/release/deps/" >> $GITHUB_ENV
+
             - name: Build client
               working-directory: ./go
               run: make build
@@ -78,16 +82,7 @@ jobs:
 
             - name: Run tests
               working-directory: ./go
-              run: make test-and-report
-
-            - name: Upload test reports
-              if: always()
-              continue-on-error: true
-              uses: actions/upload-artifact@v4
-              with:
-                  name: test-reports-go-${{ matrix.go }}-redis-${{ matrix.redis }}-${{ matrix.os }}
-                  path: |
-                      go/reports/test-report.html
+              run: make test
 
     build-amazonlinux-latest:
         if: github.repository_owner == 'aws'
@@ -153,15 +148,7 @@ jobs:
 
             - name: Run tests
               working-directory: ./go
-              run: make test-and-report
-
-            - name: Upload test reports
-              if: always()
-              continue-on-error: true
-              uses: actions/upload-artifact@v4
-              with:
-                  name: test-reports-go-${{ matrix.go }}-amazon-linux-latest
-                  path: go/reports/test-report.html
+              run: make test
 
     lint-rust:
         timeout-minutes: 15

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,7 +70,7 @@ jobs:
 
             - name: Set LD_LIBRARY_PATH
               if: ${{ matrix.os == 'ubuntu-latest' }}
-              run: echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/go/target/release/deps/" >> $GITHUB_ENV
+              run: echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/go/target/release/deps/" >> $GITHUB_ENV
 
             - name: Build client
               working-directory: ./go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
     build-and-test-go-client:
-        timeout-minutes: 45
+        timeout-minutes: 35
         strategy:
             # Run all jobs
             fail-fast: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,6 @@
 name: Go CI
 
 on:
-    workflow_dispatch:
     push:
         branches: [ "main" ]
         paths:

--- a/go/Makefile
+++ b/go/Makefile
@@ -46,9 +46,7 @@ lint:
 	gofumpt -d .
 	golines --dry-run --shorten-comments -m 127 .
 
-lint-ci:
-	go vet ./...
-	staticcheck ./...
+lint-ci: lint
 	if [ "$$(gofumpt -l . | wc -l)" -gt 0 ]; then exit 1; fi
 	if [ "$$(golines -l --shorten-comments -m 127 . | wc -l)" -gt 0 ]; then exit 1; fi
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -21,11 +21,8 @@ install-tools-go1.22.0: install-build-tools install-dev-tools-go1.22.0
 
 install-tools: install-tools-go1.22.0
 
-build: build-glide-core build-glide-client generate-protobuf
+build: build-glide-client generate-protobuf
 	go build ./...
-
-build-glide-core:
-	cd ../glide-core; cargo build --release
 
 build-glide-client:
 	cargo build --release
@@ -55,8 +52,8 @@ format:
 	golines -w --shorten-comments -m 127 .
 
 test:
-	go test -v -race `go list ./... | grep -v protobuf`
+	go test -v -race ./...
 
 test-and-report:
 	mkdir -p reports
-	go test -v -race `go list ./... | grep -v protobuf` -json | go-test-report -o reports/test-report.html
+	go test -v -race ./... -json | go-test-report -o reports/test-report.html


### PR DESCRIPTION
- remove workflow_dispatch
- increase build timeout since other branches are hitting the 20 minute limit
- set LD_LIBRARY_PATH on ubuntu to fix error seen on other branches where libglide_rs.so could not be found. Note that this problem does not occur on mac
- remove the test report from CI. On other branches, it was discovered that the command to build the test report could hide build errors when running the tests. The test report also did not allow for logging test outcomes to GH actions at the same time as creating the report.
- remove unnecessary `cargo build` for glide-core. glide-core is built automatically when we run `cargo build` for the wrapper FFI lib.rs, so it was being built twice
- improve lint output when committed files do not match the required format