### PR TITLE
Javadoc fixes.

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -98,10 +98,10 @@ public abstract class BaseClient
     /**
      * Async request for an async (non-blocking) Redis client.
      *
-     * @param config Redis client Configuration
-     * @param constructor Redis client constructor reference
-     * @param <T> Client type
-     * @return a Future to connect and return a RedisClient
+     * @param config Redis client Configuration.
+     * @param constructor Redis client constructor reference.
+     * @param <T> Client type.
+     * @return a Future to connect and return a RedisClient.
      */
     protected static <T> CompletableFuture<T> CreateClient(
             BaseClientConfiguration config,
@@ -163,12 +163,12 @@ public abstract class BaseClient
      * value as an object of type {@link T}. If <code>isNullable</code>, than also returns <code>null
      * </code>.
      *
-     * @param response Redis protobuf message
-     * @param classType Parameter {@link T} class type
-     * @param isNullable Accepts null values in the protobuf message
-     * @return Response as an object of type {@link T} or <code>null</code>
-     * @param <T> return type
-     * @throws RedisException on a type mismatch
+     * @param response Redis protobuf message,
+     * @param classType Parameter {@link T} class type.
+     * @param isNullable Accepts null values in the protobuf message.
+     * @return Response as an object of type {@link T} or <code>null</code>.
+     * @param <T> return type.
+     * @throws RedisException on a type mismatch.
      */
     @SuppressWarnings("unchecked")
     protected <T> T handleRedisResponse(Class<T> classType, boolean isNullable, Response response)
@@ -227,8 +227,8 @@ public abstract class BaseClient
 
     /**
      * @param response A Protobuf response
-     * @return A map of <code>String</code> to <code>V</code>
-     * @param <V> Value type
+     * @return A map of <code>String</code> to <code>V</code>.
+     * @param <V> Value type.
      */
     @SuppressWarnings("unchecked") // raw Map cast to Map<String, V>
     protected <V> Map<String, V> handleMapResponse(Response response) throws RedisException {

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
@@ -13,7 +13,8 @@ import java.util.concurrent.CompletableFuture;
 public interface ConnectionManagementClusterCommands {
 
     /**
-     * Ping the Redis server. The command will be routed to all primaries.
+     * Pings the Redis server.<br>
+     * The command will be routed to all primary nodes.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @return <code>String</code> with <code>"PONG"</code>.
@@ -26,7 +27,8 @@ public interface ConnectionManagementClusterCommands {
     CompletableFuture<String> ping();
 
     /**
-     * Ping the Redis server. The command will be routed to all primaries.
+     * Pings the Redis server.<br>
+     * The command will be routed to all primary nodes.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param message The server will respond with a copy of the message.
@@ -40,7 +42,7 @@ public interface ConnectionManagementClusterCommands {
     CompletableFuture<String> ping(String message);
 
     /**
-     * Ping the Redis server.
+     * Pings the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param route Specifies the routing configuration for the command. The client will route the
@@ -55,7 +57,7 @@ public interface ConnectionManagementClusterCommands {
     CompletableFuture<String> ping(Route route);
 
     /**
-     * Ping the Redis server.
+     * Pings the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param message The ping argument that will be returned.

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture;
 public interface ConnectionManagementCommands {
 
     /**
-     * Ping the Redis server.
+     * Pings the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @return <code>String</code> with <code>"PONG"</code>.
@@ -24,7 +24,7 @@ public interface ConnectionManagementCommands {
     CompletableFuture<String> ping();
 
     /**
-     * Ping the Redis server.
+     * Pings the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param message The server will respond with a copy of the message.

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -22,7 +22,7 @@ public interface GenericBaseCommands {
      * @example
      *     <pre>{@code
      * Long num = client.del(new String[] {"key1", "key2"}).get();
-     * assert num == 2l;
+     * assert num == 2L;
      * }</pre>
      */
     CompletableFuture<Long> del(String[] keys);

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -95,7 +95,7 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/expire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param seconds The timeout in seconds.
-     * @param expireOptions The expiration options.
+     * @param expireOptions The expire options.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
      *     arguments.
@@ -143,7 +143,7 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/expireat/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param unixSeconds The timeout in an absolute Unix timestamp.
-     * @param expireOptions The expiration options.
+     * @param expireOptions The expire options.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
      *     arguments.
@@ -191,7 +191,7 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/pexpire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param milliseconds The timeout in milliseconds.
-     * @param expireOptions The expiration options.
+     * @param expireOptions The expire options.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
      *     arguments.

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -261,8 +261,8 @@ public interface GenericBaseCommands {
      *     if <code>key</code> exists but has no associated expire.
      * @example
      *     <pre>{@code
-     * Long timeRemaining = client.ttl("my_key").get()
-     * assert timeRemaining == 3600L //Indicates that "my_key" has a remaining time to live of 3600 seconds.
+     * Long timeRemaining = client.ttl("my_key").get();
+     * assert timeRemaining == 3600L; //Indicates that "my_key" has a remaining time to live of 3600 seconds.
      *
      * Long timeRemaining = client.ttl("nonexistent_key").get();
      * assert timeRemaining == -2L; //Returns -2 for a non-existing key.

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -95,7 +95,7 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/expire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param seconds The timeout in seconds.
-     * @param expireOptions The expire options.
+     * @param expireOptions The expiration options.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
      *     arguments.
@@ -143,7 +143,7 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/expireat/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param unixSeconds The timeout in an absolute Unix timestamp.
-     * @param expireOptions The expire options.
+     * @param expireOptions The expiration options.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
      *     arguments.
@@ -191,7 +191,7 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/pexpire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param milliseconds The timeout in milliseconds.
-     * @param expireOptions The expire options.
+     * @param expireOptions The expiration options.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
      *     arguments.

--- a/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
@@ -16,7 +16,7 @@ public interface GenericClusterCommands {
 
     /**
      * Executes a single command, without checking inputs. Every part of the command, including
-     * subcommands, should be added as a separate value in {@code args}.
+     * subcommands, should be added as a separate value in <code>args</code>.
      *
      * <p>The command will be routed to all primaries.
      *
@@ -37,7 +37,7 @@ public interface GenericClusterCommands {
 
     /**
      * Executes a single command, without checking inputs. Every part of the command, including
-     * subcommands, should be added as a separate value in {@code args}.
+     * subcommands, should be added as a separate value in <code>args</code>.
      *
      * <p>Client will route the command to the nodes defined by <code>route</code>.
      *
@@ -61,7 +61,7 @@ public interface GenericClusterCommands {
     CompletableFuture<ClusterValue<Object>> customCommand(String[] args, Route route);
 
     /**
-     * Execute a transaction by processing the queued commands.
+     * Executes a transaction by processing the queued commands.
      *
      * <p>The transaction will be routed to the slot owner of the first key found in the transaction.
      * If no key is found, the command will be sent to a random node.
@@ -88,7 +88,7 @@ public interface GenericClusterCommands {
     CompletableFuture<Object[]> exec(ClusterTransaction transaction);
 
     /**
-     * Execute a transaction by processing the queued commands.
+     * Executes a transaction by processing the queued commands.
      *
      * @see <a href="https://redis.io/topics/Transactions/">redis.io</a> for details on Redis
      *     Transactions.

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -13,30 +13,27 @@ public interface GenericCommands {
 
     /**
      * Executes a single command, without checking inputs. Every part of the command, including
-     * subcommands, should be added as a separate value in args.
+     * subcommands, should be added as a separate value in <code>args</code>.
      *
+     * @param args Arguments for the custom command.
+     * @return Response from Redis containing an <code>Object</code>.
      * @remarks This function should only be used for single-response commands. Commands that don't
      *     return response (such as <em>SUBSCRIBE</em>), or that return potentially more than a single
      *     response (such as <em>XREAD</em>), or that change the client's behavior (such as entering
      *     <em>pub</em>/<em>sub</em> mode on <em>RESP2</em> connections) shouldn't be called using
      *     this function.
-     * @example Returns a list of all pub/sub clients:
-     *     <pre>
-     * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();
-     * </pre>
-     *
-     * @param args Arguments for the custom command.
-     * @return Response from Redis containing an <code>Object</code>.
      * @example
      *     <pre>{@code
      * Object response = (String) client.customCommand(new String[] {"ping", "GLIDE"}).get()
      * assert ((String) response).equals("GLIDE");
+     * // Get a list of all pub/sub clients:
+     * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();
      * }</pre>
      */
     CompletableFuture<Object> customCommand(String[] args);
 
     /**
-     * Execute a transaction by processing the queued commands.
+     * Executes a transaction by processing the queued commands.
      *
      * @see <a href="https://redis.io/topics/Transactions/">redis.io</a> for details on Redis
      *     Transactions.

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -24,7 +24,7 @@ public interface GenericCommands {
      *     this function.
      * @example
      *     <pre>{@code
-     * Object response = (String) client.customCommand(new String[] {"ping", "GLIDE"}).get()
+     * Object response = (String) client.customCommand(new String[] {"ping", "GLIDE"}).get();
      * assert ((String) response).equals("GLIDE");
      * // Get a list of all pub/sub clients:
      * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();

--- a/java/client/src/main/java/glide/api/commands/HashBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/HashBaseCommands.java
@@ -59,7 +59,7 @@ public interface HashBaseCommands {
      *     If <code>key</code> does not exist, it is treated as an empty hash and it returns 0.<br>
      * @example
      *     <pre>{@code
-     * Long num = client.hdel("my_hash", new String[] {}).get("field1", "field2");
+     * Long num = client.hdel("my_hash", new String[] {"field1", "field2"}).get();
      * assert num == 2L; //Indicates that two fields were successfully removed from the hash.
      * }</pre>
      */

--- a/java/client/src/main/java/glide/api/commands/HashBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/HashBaseCommands.java
@@ -142,7 +142,7 @@ public interface HashBaseCommands {
     CompletableFuture<Long> hincrBy(String key, String field, long amount);
 
     /**
-     * Increment the string representing a floating point number stored at <code>field</code> in the
+     * Increments the string representing a floating point number stored at <code>field</code> in the
      * hash stored at <code>key</code> by increment. By using a negative increment value, the value
      * stored at <code>field</code> in the hash stored at <code>key</code> is decremented. If <code>
      * field</code> or <code>key</code> does not exist, it is set to 0 before performing the
@@ -154,7 +154,7 @@ public interface HashBaseCommands {
      *     value.
      * @param amount The amount by which to increment or decrement the field's value. Use a negative
      *     value to decrement.
-     * @returns The value of <code>field</code> in the hash stored at <code>key</code> after the
+     * @return The value of <code>field</code> in the hash stored at <code>key</code> after the
      *     increment or decrement.
      * @example
      *     <pre>{@code

--- a/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
@@ -91,14 +91,14 @@ public interface ListBaseCommands {
      *     If <code>key</code> does not exist an empty array will be returned.
      * @example
      *     <pre>{@code
-     * String[] payload = lient.lrange("my_list", 0, 2).get()
-     * assert payload.equals(new String[] {"value1", "value2", "value3"})
+     * String[] payload = lient.lrange("my_list", 0, 2).get();
+     * assert payload.equals(new String[] {"value1", "value2", "value3"});
      *
-     * String[] payload = client.lrange("my_list", -2, -1).get()
-     * assert payload.equals(new String[] {"value2", "value3"})
+     * String[] payload = client.lrange("my_list", -2, -1).get();
+     * assert payload.equals(new String[] {"value2", "value3"});
      *
-     * String[] payload = client.lrange("non_exiting_key", 0, 2).get()
-     * assert payload.equals(new String[] {})
+     * String[] payload = client.lrange("non_exiting_key", 0, 2).get();
+     * assert payload.equals(new String[] {});
      * }</pre>
      */
     CompletableFuture<String[]> lrange(String key, long start, long end);
@@ -181,11 +181,11 @@ public interface ListBaseCommands {
      * @return The length of the list after the push operations.
      * @example
      *     <pre>{@code
-     * Long pushCount1 = client.rpush("my_list", new String[] {"value1", "value2"}).get()
-     * assert pushCount1 == 2L
+     * Long pushCount1 = client.rpush("my_list", new String[] {"value1", "value2"}).get();
+     * assert pushCount1 == 2L;
      *
-     * Long pushCount2 = client.rpush("nonexistent_list", new String[] {"new_value"}).get()
-     * assert pushCount2 == 1L
+     * Long pushCount2 = client.rpush("nonexistent_list", new String[] {"new_value"}).get();
+     * assert pushCount2 == 1L;
      * }</pre>
      */
     CompletableFuture<Long> rpush(String key, String[] elements);

--- a/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
@@ -38,8 +38,8 @@ public interface ListBaseCommands {
      *
      * @see <a href="https://redis.io/commands/lpop/">redis.io</a> for details.
      * @param key The key of the list.
-     * @return The value of the first element. <br>
-     *     If <code>key</code> does not exist, null will be returned. <br>
+     * @return The value of the first element.<br>
+     *     If <code>key</code> does not exist, null will be returned.
      * @example
      *     <pre>{@code
      * String value1 = client.lpop("my_list").get();
@@ -59,7 +59,7 @@ public interface ListBaseCommands {
      * @param key The key of the list.
      * @param count The count of the elements to pop from the list.
      * @return An array of the popped elements will be returned depending on the list's length.<br>
-     *     If <code>key</code> does not exist, null will be returned.<br>
+     *     If <code>key</code> does not exist, null will be returned.
      * @example
      *     <pre>{@code
      * String[] values1 = client.lpopCount("my_list", 2).get();
@@ -73,10 +73,11 @@ public interface ListBaseCommands {
 
     /**
      * Returns the specified elements of the list stored at <code>key</code>.<br>
-     * The offsets <code>start</code> and <code>end</code> are zero-based indexes, with 0 being the
-     * first element of the list, 1 being the next element and so on. These offsets can also be
-     * negative numbers indicating offsets starting at the end of the list, with -1 being the last
-     * element of the list, -2 being the penultimate, and so on.
+     * The offsets <code>start</code> and <code>end</code> are zero-based indexes, with <code>0</code>
+     * being the first element of the list, <code>1</code> being the next element and so on. These
+     * offsets can also be negative numbers indicating offsets starting at the end of the list, with
+     * <code>-1</code> being the last element of the list, <code>-2</code> being the penultimate, and
+     * so on.
      *
      * @see <a href="https://redis.io/commands/lrange/">redis.io</a> for details.
      * @param key The key of the list.
@@ -87,7 +88,7 @@ public interface ListBaseCommands {
      *     <code>end</code>, an empty array will be returned.<br>
      *     If <code>end</code> exceeds the actual end of the list, the range will stop at the actual
      *     end of the list.<br>
-     *     If <code>key</code> does not exist an empty array will be returned.<br>
+     *     If <code>key</code> does not exist an empty array will be returned.
      * @example
      *     <pre>{@code
      * String[] payload = lient.lrange("my_list", 0, 2).get()
@@ -134,7 +135,8 @@ public interface ListBaseCommands {
      * @see <a href="https://redis.io/commands/llen/">redis.io</a> for details.
      * @param key The key of the list.
      * @return The length of the list at <code>key</code>.<br>
-     *     If <code>key</code> does not exist, it is interpreted as an empty list and 0 is returned.
+     *     If <code>key</code> does not exist, it is interpreted as an empty list and <code>0</code>
+     *     is returned.
      * @example
      *     <pre>{@code
      * Long lenList = client.llen("my_list").get();
@@ -151,14 +153,14 @@ public interface ListBaseCommands {
      * If <code>count</code> is negative: Removes elements equal to <code>element</code> moving from
      * tail to head.<br>
      * If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of elements
-     * equal to <code>element</code>, it removes all elements equal to <code>element</code>.<br>
+     * equal to <code>element</code>, it removes all elements equal to <code>element</code>.
      *
      * @see <a href="https://redis.io/commands/lrem/">redis.io</a> for details.
      * @param key The key of the list.
      * @param count The count of the occurrences of elements equal to <code>element</code> to remove.
      * @param element The element to remove from the list.
      * @return The number of the removed elements.<br>
-     *     If <code>key</code> does not exist, 0 is returned.<br>
+     *     If <code>key</code> does not exist, <code>0</code> is returned.
      * @example
      *     <pre>{@code
      * Long num = client.rem("my_list", 2, "value").get();
@@ -195,7 +197,7 @@ public interface ListBaseCommands {
      * @see <a href="https://redis.io/commands/rpop/">redis.io</a> for details.
      * @param key The key of the list.
      * @return The value of the last element.<br>
-     *     If <code>key</code> does not exist, null will be returned.<br>
+     *     If <code>key</code> does not exist, <code>null</code> will be returned.
      * @example
      *     <pre>{@code
      * String value1 = client.rpop("my_list").get();
@@ -213,8 +215,8 @@ public interface ListBaseCommands {
      *
      * @see <a href="https://redis.io/commands/rpop/">redis.io</a> for details.
      * @param count The count of the elements to pop from the list.
-     * @returns An array of popped elements will be returned depending on the list's length.<br>
-     *     If <code>key</code> does not exist, null will be returned.<br>
+     * @return An array of popped elements will be returned depending on the list's length.<br>
+     *     If <code>key</code> does not exist, <code>null</code> will be returned.
      * @example
      *     <pre>{@code
      * String[] values1 = client.rpopCount("my_list", 2).get();

--- a/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
@@ -17,8 +17,8 @@ import java.util.concurrent.CompletableFuture;
 public interface ServerManagementClusterCommands {
 
     /**
-     * Get information and statistics about the Redis server using the {@link Section#DEFAULT} option.
-     * The command will be routed to all primary nodes.
+     * Gets information and statistics about the Redis server using the {@link Section#DEFAULT}
+     * option. The command will be routed to all primary nodes.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
      * @return Response from Redis cluster with a <code>Map{@literal <String, String>}</code> with
@@ -35,7 +35,7 @@ public interface ServerManagementClusterCommands {
     CompletableFuture<ClusterValue<String>> info();
 
     /**
-     * Get information and statistics about the Redis server. If no argument is provided, so the
+     * Gets information and statistics about the Redis server. If no argument is provided, so the
      * {@link Section#DEFAULT} option is assumed.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
@@ -57,7 +57,7 @@ public interface ServerManagementClusterCommands {
     CompletableFuture<ClusterValue<String>> info(Route route);
 
     /**
-     * Get information and statistics about the Redis server. The command will be routed to all
+     * Gets information and statistics about the Redis server. The command will be routed to all
      * primary nodes.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
@@ -79,7 +79,7 @@ public interface ServerManagementClusterCommands {
     CompletableFuture<ClusterValue<String>> info(InfoOptions options);
 
     /**
-     * Get information and statistics about the Redis server.
+     * Gets information and statistics about the Redis server.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
      * @param options A list of {@link InfoOptions.Section} values specifying which sections of

--- a/java/client/src/main/java/glide/api/commands/ServerManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementCommands.java
@@ -14,7 +14,8 @@ import java.util.concurrent.CompletableFuture;
 public interface ServerManagementCommands {
 
     /**
-     * Get information and statistics about the Redis server using the {@link Section#DEFAULT} option.
+     * Gets information and statistics about the Redis server using the {@link Section#DEFAULT}
+     * option.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
      * @return Response from Redis containing a <code>String</code> with the information for the
@@ -44,7 +45,7 @@ public interface ServerManagementCommands {
     CompletableFuture<String> info(InfoOptions options);
 
     /**
-     * Change the currently selected Redis database.
+     * Changes the currently selected Redis database.
      *
      * @see <a href="https://redis.io/commands/select/">redis.io</a> for details.
      * @param index The index of the database to select.

--- a/java/client/src/main/java/glide/api/commands/SetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetBaseCommands.java
@@ -12,8 +12,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface SetBaseCommands {
     /**
-     * Add specified members to the set stored at <code>key</code>. Specified members that are already
-     * a member of this set are ignored.
+     * Adds specified members to the set stored at <code>key</code>. Specified members that are
+     * already a member of this set are ignored.
      *
      * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
      * @param key The <code>key</code> where members will be added to its set.
@@ -30,7 +30,7 @@ public interface SetBaseCommands {
     CompletableFuture<Long> sadd(String key, String[] members);
 
     /**
-     * Remove specified members from the set stored at <code>key</code>. Specified members that are
+     * Removes specified members from the set stored at <code>key</code>. Specified members that are
      * not a member of this set are ignored.
      *
      * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
@@ -38,7 +38,7 @@ public interface SetBaseCommands {
      * @param members A list of members to remove from the set stored at <code>key</code>.
      * @return The number of members that were removed from the set, excluding non-existing members.
      * @remarks If <code>key</code> does not exist, it is treated as an empty set and this command
-     *     returns 0.
+     *     returns <code>0</code>.
      * @example
      *     <pre>{@code
      * Long result = client.srem("my_set", new String[]{"member1", "member2"}).get();
@@ -48,7 +48,7 @@ public interface SetBaseCommands {
     CompletableFuture<Long> srem(String key, String[] members);
 
     /**
-     * Retrieve all the members of the set value stored at <code>key</code>.
+     * Retrieves all the members of the set value stored at <code>key</code>.
      *
      * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
      * @param key The key from which to retrieve the set members.
@@ -63,7 +63,7 @@ public interface SetBaseCommands {
     CompletableFuture<Set<String>> smembers(String key);
 
     /**
-     * Retrieve the set cardinality (number of elements) of the set stored at <code>key</code>.
+     * Retrieves the set cardinality (number of elements) of the set stored at <code>key</code>.
      *
      * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
      * @param key The key from which to retrieve the number of set members.

--- a/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
@@ -23,7 +23,7 @@ public interface SortedSetBaseCommands {
      * @param options The Zadd options.
      * @param changed Modify the return value from the number of new elements added, to the total
      *     number of elements changed.
-     * @return The number of elements added to the sorted set. <br>
+     * @return The number of elements added to the sorted set.<br>
      *     If <code>changed</code> is set, returns the number of elements updated in the sorted set.
      * @example
      *     <pre>{@code
@@ -67,9 +67,8 @@ public interface SortedSetBaseCommands {
      * @param membersScoresMap A <code>Map</code> of members to their corresponding scores.
      * @param changed Modify the return value from the number of new elements added, to the total
      *     number of elements changed.
-     * @return The number of elements added to the sorted set. <br>
+     * @return The number of elements added to the sorted set.<br>
      *     If <code>changed</code> is set, returns the number of elements updated in the sorted set.
-     *     <br>
      * @example
      *     <pre>{@code
      * Long num = client.zadd("mySortedSet", Map.of("member1", 10.5, "member2", 8.2), true).get();
@@ -98,7 +97,7 @@ public interface SortedSetBaseCommands {
      * Increments the score of member in the sorted set stored at <code>key</code> by <code>increment
      * </code>.<br>
      * If <code>member</code> does not exist in the sorted set, it is added with <code>
-     * increment</code> as its score (as if its previous score was 0.0).<br>
+     * increment</code> as its score (as if its previous score was <code>0.0</code>).<br>
      * If <code>key</code> does not exist, a new sorted set with the specified member as its sole
      * member is created.
      *
@@ -109,7 +108,7 @@ public interface SortedSetBaseCommands {
      * @param options The Zadd options.
      * @return The score of the member.<br>
      *     If there was a conflict with the options, the operation aborts and <code>null</code> is
-     *     returned.<br>
+     *     returned.
      * @example
      *     <pre>{@code
      * Double num = client.zaddIncr("mySortedSet", member, 5.0, ZaddOptions.builder().build()).get();
@@ -126,7 +125,7 @@ public interface SortedSetBaseCommands {
      * Increments the score of member in the sorted set stored at <code>key</code> by <code>increment
      * </code>.<br>
      * If <code>member</code> does not exist in the sorted set, it is added with <code>
-     * increment</code> as its score (as if its previous score was 0.0).<br>
+     * increment</code> as its score (as if its previous score was <code>0.0</code>).<br>
      * If <code>key</code> does not exist, a new sorted set with the specified member as its sole
      * member is created.
      *

--- a/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
@@ -27,10 +27,12 @@ public interface SortedSetBaseCommands {
      *     If <code>changed</code> is set, returns the number of elements updated in the sorted set.
      * @example
      *     <pre>{@code
-     * Long num = client.zadd("mySortedSet", Map.of("member1", 10.5, "member2", 8.2), ZaddOptions.builder().build(), false).get();
+     * ZaddOptions options = ZaddOptions.builder().build();
+     * Long num = client.zadd("mySortedSet", Map.of("member1", 10.5, "member2", 8.2), options, false).get();
      * assert num == 2L; // Indicates that two elements have been added or updated in the sorted set "mySortedSet".
      *
-     * Long num = client.zadd("existingSortedSet", Map.of("member1", 15.0, "member2", 5.5), ZaddOptions.builder().conditionalChange(ZaddOptions.ConditionalChange.ONLY_IF_EXISTS).build(), false).get();
+     * options = ZaddOptions.builder().conditionalChange(ONLY_IF_EXISTS).build();
+     * Long num = client.zadd("existingSortedSet", Map.of("member1", 15.0, "member2", 5.5), options, false).get();
      * assert num == 2L; // Updates the scores of two existing members in the sorted set "existingSortedSet".
      * }</pre>
      */
@@ -48,10 +50,12 @@ public interface SortedSetBaseCommands {
      * @return The number of elements added to the sorted set.
      * @example
      *     <pre>{@code
-     * Long num = client.zadd("mySortedSet", Map.of("member1", 10.5, "member2", 8.2), ZaddOptions.builder().build()).get();
+     * ZaddOptions options = ZaddOptions.builder().build();
+     * Long num = client.zadd("mySortedSet", Map.of("member1", 10.5, "member2", 8.2), options).get();
      * assert num == 2L; // Indicates that two elements have been added to the sorted set "mySortedSet".
      *
-     * Long num = client.zadd("existingSortedSet", Map.of("member1", 15.0, "member2", 5.5), ZaddOptions.builder().conditionalChange(ZaddOptions.ConditionalChange.ONLY_IF_EXISTS).build()).get();
+     * options = ZaddOptions.builder().conditionalChange(ONLY_IF_EXISTS).build();
+     * Long num = client.zadd("existingSortedSet", Map.of("member1", 15.0, "member2", 5.5), options).get();
      * assert num == 0L; // No new members were added to the sorted set "existingSortedSet".
      * }</pre>
      */
@@ -111,10 +115,12 @@ public interface SortedSetBaseCommands {
      *     returned.
      * @example
      *     <pre>{@code
-     * Double num = client.zaddIncr("mySortedSet", member, 5.0, ZaddOptions.builder().build()).get();
+     * ZaddOptions options = ZaddOptions.builder().build();
+     * Double num = client.zaddIncr("mySortedSet", member, 5.0, ).get();
      * assert num == 5.0;
      *
-     * Double num = client.zaddIncr("existingSortedSet", member, 3.0, ZaddOptions.builder().updateOptions(ZaddOptions.UpdateOptions.SCORE_LESS_THAN_CURRENT).build()).get();
+     * options = ZaddOptions.builder().updateOptions(SCORE_LESS_THAN_CURRENT).build();
+     * Double num = client.zaddIncr("existingSortedSet", member, 3.0, options).get();
      * assert num == null;
      * }</pre>
      */

--- a/java/client/src/main/java/glide/api/commands/StringCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringCommands.java
@@ -16,8 +16,8 @@ import java.util.concurrent.CompletableFuture;
 public interface StringCommands {
 
     /**
-     * Get the value associated with the given <code>key</code>, or <code>null</code> if no such value
-     * exists.
+     * Gets the value associated with the given <code>key</code>, or <code>null</code> if no such
+     * value exists.
      *
      * @see <a href="https://redis.io/commands/get/">redis.io</a> for details.
      * @param key The <code>key</code> to retrieve from the database.
@@ -35,7 +35,7 @@ public interface StringCommands {
     CompletableFuture<String> get(String key);
 
     /**
-     * Set the given <code>key</code> with the given value.
+     * Sets the given <code>key</code> with the given value.
      *
      * @see <a href="https://redis.io/commands/set/">redis.io</a> for details.
      * @param key The <code>key</code> to store.
@@ -50,7 +50,7 @@ public interface StringCommands {
     CompletableFuture<String> set(String key, String value);
 
     /**
-     * Set the given key with the given value. Return value is dependent on the passed options.
+     * Sets the given key with the given value. Return value is dependent on the passed options.
      *
      * @see <a href="https://redis.io/commands/set/">redis.io</a> for details.
      * @param key The key to store.
@@ -75,7 +75,7 @@ public interface StringCommands {
     CompletableFuture<String> set(String key, String value, SetOptions options);
 
     /**
-     * Retrieve the values of multiple <code>keys</code>.
+     * Retrieves the values of multiple <code>keys</code>.
      *
      * @see <a href="https://redis.io/commands/mget/">redis.io</a> for details.
      * @param keys A list of keys to retrieve values for.
@@ -91,7 +91,7 @@ public interface StringCommands {
     CompletableFuture<String[]> mget(String[] keys);
 
     /**
-     * Set multiple keys to multiple values in a single operation.
+     * Sets multiple keys to multiple values in a single operation.
      *
      * @see <a href="https://redis.io/commands/mset/">redis.io</a> for details.
      * @param keyValueMap A key-value map consisting of keys and their respective values to set.
@@ -105,7 +105,7 @@ public interface StringCommands {
     CompletableFuture<String> mset(Map<String, String> keyValueMap);
 
     /**
-     * Increment the number stored at <code>key</code> by one. If <code>key</code> does not exist, it
+     * Increments the number stored at <code>key</code> by one. If <code>key</code> does not exist, it
      * is set to 0 before performing the operation.
      *
      * @see <a href="https://redis.io/commands/incr/">redis.io</a> for details.
@@ -120,7 +120,7 @@ public interface StringCommands {
     CompletableFuture<Long> incr(String key);
 
     /**
-     * Increment the number stored at <code>key</code> by <code>amount</code>. If <code>key</code>
+     * Increments the number stored at <code>key</code> by <code>amount</code>. If <code>key</code>
      * does not exist, it is set to 0 before performing the operation.
      *
      * @see <a href="https://redis.io/commands/incrby/">redis.io</a> for details.
@@ -136,7 +136,7 @@ public interface StringCommands {
     CompletableFuture<Long> incrBy(String key, long amount);
 
     /**
-     * Increment the string representing a floating point number stored at <code>key</code> by <code>
+     * Increments the string representing a floating point number stored at <code>key</code> by <code>
      * amount</code>. By using a negative increment value, the result is that the value stored at
      * <code>key</code> is decremented. If <code>key</code> does not exist, it is set to 0 before
      * performing the operation.
@@ -154,7 +154,7 @@ public interface StringCommands {
     CompletableFuture<Double> incrByFloat(String key, double amount);
 
     /**
-     * Decrement the number stored at <code>key</code> by one. If <code>key</code> does not exist, it
+     * Decrements the number stored at <code>key</code> by one. If <code>key</code> does not exist, it
      * is set to 0 before performing the operation.
      *
      * @see <a href="https://redis.io/commands/decr/">redis.io</a> for details.
@@ -169,7 +169,7 @@ public interface StringCommands {
     CompletableFuture<Long> decr(String key);
 
     /**
-     * Decrement the number stored at <code>key</code> by <code>amount</code>. If <code>key</code>
+     * Decrements the number stored at <code>key</code> by <code>amount</code>. If <code>key</code>
      * does not exist, it is set to 0 before performing the operation.
      *
      * @see <a href="https://redis.io/commands/decrby/">redis.io</a> for details.

--- a/java/client/src/main/java/glide/api/commands/StringCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringCommands.java
@@ -25,11 +25,11 @@ public interface StringCommands {
      *     <code>key</code> as a <code>String</code>. Otherwise, return <code>null</code>.
      * @example
      *     <pre>{@code
-     * String payload = client.get("key").get();
-     * assert payload.equals("value");
+     * String value = client.get("key").get();
+     * assert value.equals("value");
      *
-     * String payload = client.get("non_existing_key").get();
-     * assert payload.equals(null);
+     * String value = client.get("non_existing_key").get();
+     * assert value.equals(null);
      * }</pre>
      */
     CompletableFuture<String> get(String key);
@@ -43,8 +43,8 @@ public interface StringCommands {
      * @return Response from Redis containing <code>"OK"</code>.
      * @example
      *     <pre>{@code
-     * String payload = client.set("key", "value").get();
-     * assert payload.equals("OK");
+     * String value = client.set("key", "value").get();
+     * assert value.equals("OK");
      * }</pre>
      */
     CompletableFuture<String> set(String key, String value);
@@ -63,13 +63,9 @@ public interface StringCommands {
      *     is set, return the old value as a <code>String</code>.
      * @example
      *     <pre>{@code
-     * String payload =
-     *         client.set("key", "value", SetOptions.builder()
-     *                 .conditionalSet(ONLY_IF_EXISTS)
-     *                 .expiry(SetOptions.Expiry.Seconds(5L))
-     *                 .build())
-     *                 .get();
-     * assert payload.equals("OK");
+     * SetOptions options = SetOptions.builder().conditionalSet(ONLY_IF_EXISTS).expiry(Seconds(5L)).build();
+     * String value = client.set("key", "value", options).get();
+     * assert value.equals("OK");
      * }</pre>
      */
     CompletableFuture<String> set(String key, String value, SetOptions options);
@@ -84,8 +80,8 @@ public interface StringCommands {
      *     </code>.
      * @example
      *     <pre>{@code
-     * String payload = client.mget(new String[] {"key1", "key2"}).get();
-     * assert payload.equals(new String[] {"value1", "value2"});
+     * String values = client.mget(new String[] {"key1", "key2"}).get();
+     * assert values.equals(new String[] {"value1", "value2"});
      * }</pre>
      */
     CompletableFuture<String[]> mget(String[] keys);
@@ -98,8 +94,8 @@ public interface StringCommands {
      * @return Always <code>OK</code>.
      * @example
      *     <pre>{@code
-     * String payload = client.mset(Map.of("key1", "value1", "key2", "value2"}).get();
-     * assert payload.equals("OK"));
+     * String result = client.mset(Map.of("key1", "value1", "key2", "value2"}).get();
+     * assert result.equals("OK"));
      * }</pre>
      */
     CompletableFuture<String> mset(Map<String, String> keyValueMap);
@@ -147,7 +143,7 @@ public interface StringCommands {
      * @return The value of <code>key</code> after the increment.
      * @example
      *     <pre>{@code
-     * Long num = client.incrByFloat("key", 0.5).get();
+     * Double num = client.incrByFloat("key", 0.5).get();
      * assert num == 7.5;
      * }</pre>
      */

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -851,7 +851,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/expire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param seconds The timeout in seconds.
-     * @param expireOptions The expiration options.
+     * @param expireOptions The expire options.
      * @return Command response - <code>true</code> if the timeout was set. <code>false</code> if the
      *     timeout was not set. e.g. <code>key</code> doesn't exist, or operation skipped due to the
      *     provided arguments.
@@ -901,7 +901,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/expireat/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param unixSeconds The timeout in an absolute Unix timestamp.
-     * @param expireOptions The expiration options.
+     * @param expireOptions The expire options.
      * @return Command response - <code>true</code> if the timeout was set. <code>false</code> if the
      *     timeout was not set. e.g. <code>key</code> doesn't exist, or operation skipped due to the
      *     provided arguments.
@@ -952,7 +952,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/pexpire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param milliseconds The timeout in milliseconds.
-     * @param expireOptions The expiration options.
+     * @param expireOptions The expire options.
      * @return Command response - <code>true</code> if the timeout was set. <code>false</code> if the
      *     timeout was not set. e.g. <code>key</code> doesn't exist, or operation skipped due to the
      *     provided arguments.

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -92,18 +92,17 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Executes a single command, without checking inputs. Every part of the command, including
      * subcommands, should be added as a separate value in args.
      *
+     * @param args Arguments for the custom command.
+     * @return A response from Redis with an <code>Object</code>.
      * @remarks This function should only be used for single-response commands. Commands that don't
      *     return response (such as <em>SUBSCRIBE</em>), or that return potentially more than a single
      *     response (such as <em>XREAD</em>), or that change the client's behavior (such as entering
      *     <em>pub</em>/<em>sub</em> mode on <em>RESP2</em> connections) shouldn't be called using
      *     this function.
      * @example Returns a list of all pub/sub clients:
-     *     <pre>
+     *     <pre>{@code
      * Object result = client.customCommand(new String[]{ "CLIENT", "LIST", "TYPE", "PUBSUB" }).get();
-     * </pre>
-     *
-     * @param args Arguments for the custom command.
-     * @return A response from Redis with an <code>Object</code>.
+     * }</pre>
      */
     public T customCommand(String[] args) {
 
@@ -113,10 +112,10 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Ping the Redis server.
+     * Pings the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
-     * @return A response from Redis with a <code>String</code>.
+     * @return Command Response - A response from Redis with a <code>String</code>.
      */
     public T ping() {
         protobufTransaction.addCommands(buildCommand(Ping));
@@ -124,11 +123,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Ping the Redis server.
+     * Pings the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param msg The ping argument that will be returned.
-     * @return A response from Redis with a <code>String</code>.
+     * @return Command Response - A response from Redis with a <code>String</code>.
      */
     public T ping(@NonNull String msg) {
         ArgsArray commandArgs = buildArgs(msg);
@@ -138,10 +137,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Get information and statistics about the Redis server using the {@link Section#DEFAULT} option.
+     * Gets information and statistics about the Redis server using the {@link Section#DEFAULT}
+     * option.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
-     * @return A response from Redis with a <code>String</code>.
+     * @return Command Response - A <code>String</code> with server info.
      */
     public T info() {
         protobufTransaction.addCommands(buildCommand(Info));
@@ -149,13 +149,12 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Get information and statistics about the Redis server.
+     * Gets information and statistics about the Redis server.
      *
      * @see <a href="https://redis.io/commands/info/">redis.io</a> for details.
      * @param options A list of {@link Section} values specifying which sections of information to
      *     retrieve. When no parameter is provided, the {@link Section#DEFAULT} option is assumed.
-     * @return Response from Redis with a <code>String</code> containing the requested {@link
-     *     Section}s.
+     * @return Command Response - A <code>String</code> containing the requested {@link Section}s.
      */
     public T info(@NonNull InfoOptions options) {
         ArgsArray commandArgs = buildArgs(options.toArgs());
@@ -180,11 +179,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Get the value associated with the given key, or null if no such value exists.
+     * Gets the value associated with the given key, or null if no such value exists.
      *
      * @see <a href="https://redis.io/commands/get/">redis.io</a> for details.
      * @param key The key to retrieve from the database.
-     * @return Response from Redis. <code>key</code> exists, returns the <code>value</code> of <code>
+     * @return Command Response - If <code>key</code> exists, returns the <code>value</code> of <code>
      *     key</code> as a String. Otherwise, return <code>null</code>.
      */
     public T get(@NonNull String key) {
@@ -195,12 +194,12 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Set the given key with the given value.
+     * Sets the given key with the given value.
      *
      * @see <a href="https://redis.io/commands/set/">redis.io</a> for details.
      * @param key The key to store.
      * @param value The value to store with the given <code>key</code>.
-     * @return Response from Redis.
+     * @return Command Response - A response from Redis.
      */
     public T set(@NonNull String key, @NonNull String value) {
         ArgsArray commandArgs = buildArgs(key, value);
@@ -210,14 +209,14 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Set the given key with the given value. Return value is dependent on the passed options.
+     * Sets the given key with the given value. Return value is dependent on the passed options.
      *
      * @see <a href="https://redis.io/commands/set/">redis.io</a> for details.
      * @param key The key to store.
      * @param value The value to store with the given key.
      * @param options The Set options.
-     * @return Response from Redis with a <code>String</code> or <code>null</code> response. The old
-     *     value as a <code>String</code> if {@link SetOptionsBuilder#returnOldValue(boolean)} is set.
+     * @return Command Response - A <code>String</code> or <code>null</code> response. The old value
+     *     as a <code>String</code> if {@link SetOptionsBuilder#returnOldValue(boolean)} is set.
      *     Otherwise, if the value isn't set because of {@link ConditionalSet#ONLY_IF_EXISTS} or
      *     {@link ConditionalSet#ONLY_IF_DOES_NOT_EXIST} conditions, return <code>null</code>.
      *     Otherwise, return <code>OK</code>.
@@ -231,7 +230,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Retrieve the values of multiple <code>keys</code>.
+     * Retrieves the values of multiple <code>keys</code>.
      *
      * @see <a href="https://redis.io/commands/mget/">redis.io</a> for details.
      * @param keys A list of keys to retrieve values for.
@@ -248,7 +247,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Set multiple keys to multiple values in a single operation.
+     * Sets multiple keys to multiple values in a single operation.
      *
      * @see <a href="https://redis.io/commands/mset/">redis.io</a> for details.
      * @param keyValueMap A key-value map consisting of keys and their respective values to set.
@@ -263,7 +262,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Increment the number stored at <code>key</code> by one. If <code>key</code> does not exist, it
+     * Increments the number stored at <code>key</code> by one. If <code>key</code> does not exist, it
      * is set to 0 before performing the operation.
      *
      * @see <a href="https://redis.io/commands/incr/">redis.io</a> for details.
@@ -278,7 +277,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Increment the number stored at <code>key</code> by <code>amount</code>. If <code>key</code>
+     * Increments the number stored at <code>key</code> by <code>amount</code>. If <code>key</code>
      * does not exist, it is set to 0 before performing the operation.
      *
      * @see <a href="https://redis.io/commands/incrby/">redis.io</a> for details.
@@ -294,7 +293,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Increment the string representing a floating point number stored at <code>key</code> by <code>
+     * Increments the string representing a floating point number stored at <code>key</code> by <code>
      * amount</code>. By using a negative increment value, the result is that the value stored at
      * <code>key</code> is decremented. If <code>key</code> does not exist, it is set to 0 before
      * performing the operation.
@@ -312,7 +311,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Decrement the number stored at <code>key</code> by one. If <code>key</code> does not exist, it
+     * Decrements the number stored at <code>key</code> by one. If <code>key</code> does not exist, it
      * is set to 0 before performing the operation.
      *
      * @see <a href="https://redis.io/commands/decr/">redis.io</a> for details.
@@ -327,7 +326,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Decrement the number stored at <code>key</code> by <code>amount</code>. If <code>key</code>
+     * Decrements the number stored at <code>key</code> by <code>amount</code>. If <code>key</code>
      * does not exist, it is set to 0 before performing the operation.
      *
      * @see <a href="https://redis.io/commands/decrby/">redis.io</a> for details.
@@ -343,14 +342,13 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Retrieve the value associated with <code>field</code> in the hash stored at <code>key</code>.
+     * Retrieves the value associated with <code>field</code> in the hash stored at <code>key</code>.
      *
      * @see <a href="https://redis.io/commands/hget/">redis.io</a> for details.
      * @param key The key of the hash.
      * @param field The field in the hash stored at <code>key</code> to retrieve from the database.
      * @return Command Response - The value associated with <code>field</code>, or <code>null</code>
-     *     when <code>field
-     *     </code> is not present in the hash or <code>key</code> does not exist.
+     *     when <code>field</code> is not present in the hash or <code>key</code> does not exist.
      */
     public T hget(@NonNull String key, @NonNull String field) {
         ArgsArray commandArgs = buildArgs(key, field);
@@ -469,7 +467,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Increment the string representing a floating point number stored at <code>field</code> in the
+     * Increments the string representing a floating point number stored at <code>field</code> in the
      * hash stored at <code>key</code> by increment. By using a negative increment value, the value
      * stored at <code>field</code> in the hash stored at <code>key</code> is decremented. If <code>
      * field</code> or <code>key</code> does not exist, it is set to 0 before performing the
@@ -481,7 +479,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     value.
      * @param amount The amount by which to increment or decrement the field's value. Use a negative
      *     value to decrement.
-     * @returns Command Response - The value of <code>field</code> in the hash stored at <code>key
+     * @return Command Response - The value of <code>field</code> in the hash stored at <code>key
      *     </code> after the increment or decrement.
      */
     public T hincrByFloat(@NonNull String key, @NonNull String field, double amount) {
@@ -515,8 +513,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://redis.io/commands/lpop/">redis.io</a> for details.
      * @param key The key of the list.
-     * @return Command Response - The value of the first element. <br>
-     *     If <code>key</code> does not exist, null will be returned. <br>
+     * @return Command Response - The value of the first element.<br>
+     *     If <code>key</code> does not exist, null will be returned.
      */
     public T lpop(@NonNull String key) {
         ArgsArray commandArgs = buildArgs(key);
@@ -534,7 +532,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param count The count of the elements to pop from the list.
      * @return Command Response - An array of the popped elements will be returned depending on the
      *     list's length.<br>
-     *     If <code>key</code> does not exist, null will be returned.<br>
+     *     If <code>key</code> does not exist, null will be returned.
      */
     public T lpopCount(@NonNull String key, long count) {
         ArgsArray commandArgs = buildArgs(key, Long.toString(count));
@@ -545,10 +543,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
 
     /**
      * Returns the specified elements of the list stored at <code>key</code>.<br>
-     * The offsets <code>start</code> and <code>end</code> are zero-based indexes, with 0 being the
-     * first element of the list, 1 being the next element and so on. These offsets can also be
-     * negative numbers indicating offsets starting at the end of the list, with -1 being the last
-     * element of the list, -2 being the penultimate, and so on.
+     * The offsets <code>start</code> and <code>end</code> are zero-based indexes, with <code>0</code>
+     * being the first element of the list, <code>1</code> being the next element and so on. These
+     * offsets can also be negative numbers indicating offsets starting at the end of the list, with
+     * <code>-1</code> being the last element of the list, <code>-2</code> being the penultimate, and
+     * so on.
      *
      * @see <a href="https://redis.io/commands/lrange/">redis.io</a> for details.
      * @param key The key of the list.
@@ -559,7 +558,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     <code>end</code>, an empty array will be returned.<br>
      *     If <code>end</code> exceeds the actual end of the list, the range will stop at the actual
      *     end of the list.<br>
-     *     If <code>key</code> does not exist an empty array will be returned.<br>
+     *     If <code>key</code> does not exist an empty array will be returned.
      */
     public T lrange(@NonNull String key, long start, long end) {
         ArgsArray commandArgs = buildArgs(key, Long.toString(start), Long.toString(end));
@@ -569,18 +568,17 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Trims an existing list so that it will contain only the specified range of elements specified.
-     * <br>
-     * The offsets <code>start</code> and <code>end</code> are zero-based indexes, with 0 being the
-     * first element of the list, 1 being the next element and so on.<br>
+     * Trims an existing list so that it will contain only the specified range of elements specified.<br>
+     * The offsets <code>start</code> and <code>end</code> are zero-based indexes, with <code>0</code> being the
+     * first element of the list, </code>1<code> being the next element and so on.<br>
      * These offsets can also be negative numbers indicating offsets starting at the end of the list,
-     * with -1 being the last element of the list, -2 being the penultimate, and so on.
+     * with <code>-1</code> being the last element of the list, <code>-2</code> being the penultimate, and so on.
      *
      * @see <a href="https://redis.io/commands/ltrim/">redis.io</a> for details.
      * @param key The key of the list.
      * @param start The starting point of the range.
      * @param end The end of the range.
-     * @return Command Response - Always <code>OK</code>. <br>
+     * @return Command Response - Always <code>OK</code>.<br>
      *     If <code>start</code> exceeds the end of the list, or if <code>start</code> is greater than
      *     <code>end</code>, the result will be an empty list (which causes key to be removed).<br>
      *     If <code>end</code> exceeds the actual end of the list, it will be treated like the last
@@ -600,7 +598,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/llen/">redis.io</a> for details.
      * @param key The key of the list.
      * @return Command Response - The length of the list at <code>key</code>.<br>
-     *     If <code>key</code> does not exist, it is interpreted as an empty list and 0 is returned.
+     *     If <code>key</code> does not exist, it is interpreted as an empty list and <code>0</code>
+     *     is returned.
      */
     public T llen(@NonNull String key) {
         ArgsArray commandArgs = buildArgs(key);
@@ -617,14 +616,14 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * If <code>count</code> is negative: Removes elements equal to <code>element</code> moving from
      * tail to head.<br>
      * If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of elements
-     * equal to <code>element</code>, it removes all elements equal to <code>element</code>.<br>
+     * equal to <code>element</code>, it removes all elements equal to <code>element</code>.
      *
      * @see <a href="https://redis.io/commands/lrem/">redis.io</a> for details.
      * @param key The key of the list.
      * @param count The count of the occurrences of elements equal to <code>element</code> to remove.
      * @param element The element to remove from the list.
      * @return Command Response - The number of the removed elements.<br>
-     *     If <code>key</code> does not exist, 0 is returned.<br>
+     *     If <code>key</code> does not exist, <code>0</code> is returned.
      */
     public T lrem(@NonNull String key, long count, @NonNull String element) {
         ArgsArray commandArgs = buildArgs(key, Long.toString(count), element);
@@ -658,7 +657,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/rpop/">redis.io</a> for details.
      * @param key The key of the list.
      * @return Command Response - The value of the last element.<br>
-     *     If <code>key</code> does not exist, null will be returned.<br>
+     *     If <code>key</code> does not exist, <code>null</code> will be returned.
      */
     public T rpop(@NonNull String key) {
         ArgsArray commandArgs = buildArgs(key);
@@ -675,7 +674,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param count The count of the elements to pop from the list.
      * @return Command Response - An array of popped elements will be returned depending on the list's
      *     length.<br>
-     *     If <code>key</code> does not exist, null will be returned.<br>
+     *     If <code>key</code> does not exist, <code>null</code> will be returned.
      */
     public T rpopCount(@NonNull String key, long count) {
         ArgsArray commandArgs = buildArgs(key, Long.toString(count));
@@ -685,8 +684,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Add specified members to the set stored at <code>key</code>. Specified members that are already
-     * a member of this set are ignored.
+     * Adds specified members to the set stored at <code>key</code>. Specified members that are
+     * already a member of this set are ignored.
      *
      * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
      * @param key The <code>key</code> where members will be added to its set.
@@ -704,7 +703,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Remove specified members from the set stored at <code>key</code>. Specified members that are
+     * Removes specified members from the set stored at <code>key</code>. Specified members that are
      * not a member of this set are ignored.
      *
      * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
@@ -713,7 +712,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @return Command Response - The number of members that were removed from the set, excluding
      *     non-existing members.
      * @remarks If <code>key</code> does not exist, it is treated as an empty set and this command
-     *     returns 0.
+     *     returns <code>0</code>.
      */
     public T srem(@NonNull String key, @NonNull String[] members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
@@ -723,7 +722,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Retrieve all the members of the set value stored at <code>key</code>.
+     * Retrieves all the members of the set value stored at <code>key</code>.
      *
      * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
      * @param key The key from which to retrieve the set members.
@@ -738,7 +737,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Retrieve the set cardinality (number of elements) of the set stored at <code>key</code>.
+     * Retrieves the set cardinality (number of elements) of the set stored at <code>key</code>.
      *
      * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
      * @param key The key from which to retrieve the number of set members.
@@ -800,7 +799,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Unlink (delete) multiple <code>keys</code> from the database. A key is ignored if it does not
+     * Unlinks (deletes) multiple <code>keys</code> from the database. A key is ignored if it does not
      * exist. This command, similar to DEL, removes specified keys and ignores non-existent ones.
      * However, this command does not block the server, while <a
      * href="https://redis.io/commands/del/">DEL</a> does.
@@ -852,7 +851,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/expire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param seconds The timeout in seconds.
-     * @param expireOptions The expire options.
+     * @param expireOptions The expiration options.
      * @return Command response - <code>true</code> if the timeout was set. <code>false</code> if the
      *     timeout was not set. e.g. <code>key</code> doesn't exist, or operation skipped due to the
      *     provided arguments.
@@ -902,7 +901,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/expireat/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param unixSeconds The timeout in an absolute Unix timestamp.
-     * @param expireOptions The expire options.
+     * @param expireOptions The expiration options.
      * @return Command response - <code>true</code> if the timeout was set. <code>false</code> if the
      *     timeout was not set. e.g. <code>key</code> doesn't exist, or operation skipped due to the
      *     provided arguments.
@@ -953,7 +952,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/pexpire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param milliseconds The timeout in milliseconds.
-     * @param expireOptions The expire options.
+     * @param expireOptions The expiration options.
      * @return Command response - <code>true</code> if the timeout was set. <code>false</code> if the
      *     timeout was not set. e.g. <code>key</code> doesn't exist, or operation skipped due to the
      *     provided arguments.
@@ -1004,7 +1003,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/pexpireat/">redis.io</a> for details.
      * @param key The <code>key</code> to set timeout on it.
      * @param unixMilliseconds The timeout in an absolute Unix timestamp.
-     * @param expireOptions The expire option.
+     * @param expireOptions The expiration option.
      * @return Command response - <code>true</code> if the timeout was set. <code>false</code> if the
      *     timeout was not set. e.g. <code>key</code> doesn't exist, or operation skipped due to the
      *     provided arguments.
@@ -1036,7 +1035,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Get the current connection id.
+     * Gets the current connection id.
      *
      * @see <a href="https://redis.io/commands/client-id/">redis.io</a> for details.
      * @return Command response - The id of the client.
@@ -1047,7 +1046,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Get the name of the current connection.
+     * Gets the name of the current connection.
      *
      * @see <a href="https://redis.io/commands/client-getname/">redis.io</a> for details.
      * @return Command response - The name of the client connection as a string if a name is set, or

--- a/java/client/src/main/java/glide/api/models/ClusterValue.java
+++ b/java/client/src/main/java/glide/api/models/ClusterValue.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * Represents a returned value object from a Redis server with cluster-mode enabled. The response
  * type may depend on the submitted {@link Route}.
  *
- * @remark ClusterValue stores values in a union-like object. It contains a single-value or
+ * @remarks ClusterValue stores values in a union-like object. It contains a single-value or
  *     multi-value response from Redis. If the command's routing is to a single node use {@link
  *     #getSingleValue()} to return a response of type <code>T</code>. Otherwise, use {@link
  *     #getMultiValue()} to return a <code>Map</code> of <code>address: nodeResponse</code> where

--- a/java/client/src/main/java/glide/api/models/Transaction.java
+++ b/java/client/src/main/java/glide/api/models/Transaction.java
@@ -32,7 +32,7 @@ public class Transaction extends BaseTransaction<Transaction> {
     }
 
     /**
-     * Change the currently selected Redis database.
+     * Changes the currently selected Redis database.
      *
      * @see <a href="https://redis.io/commands/select/">redis.io</a> for details.
      * @param index The index of the database to select.

--- a/java/client/src/main/java/glide/api/models/commands/SetOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/SetOptions.java
@@ -43,12 +43,12 @@ public final class SetOptions {
     @RequiredArgsConstructor
     @Getter
     public enum ConditionalSet {
+        /** Only set the key if it already exists. Equivalent to <code>XX</code> in the Redis API. */
+        ONLY_IF_EXISTS("XX"),
         /**
-         * Only set the key if it does not already exist. Equivalent to <code>XX</code> in the Redis
+         * Only set the key if it does not already exist. Equivalent to <code>NX</code> in the Redis
          * API.
          */
-        ONLY_IF_EXISTS("XX"),
-        /** Only set the key if it already exists. Equivalent to <code>NX</code> in the Redis API. */
         ONLY_IF_DOES_NOT_EXIST("NX");
 
         private final String redisApi;


### PR DESCRIPTION
Edits to make javadocs more consistent, including: 
* Starting javadocs in the present tense
* Adding code tags around Java objects and Java types