### PR TITLE
Fix transaction handling for cluster client.

### DIFF
--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -89,7 +89,7 @@ public class RedisClusterClient extends BaseClient
     @Override
     public CompletableFuture<Object[]> exec(
             @NonNull ClusterTransaction transaction, @NonNull Route route) {
-        assert route.isSingleNodeRoute() : "Multi-node routes are not supported for transaction";
+        assert route.isSingleNodeRoute() : "Multi-node routes are not supported for exec()";
         return commandManager.submitNewCommand(
                 transaction, Optional.of(route), this::handleArrayOrNullResponse);
     }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -26,7 +26,6 @@ import glide.api.models.configuration.RedisClusterClientConfiguration;
 import glide.api.models.configuration.RequestRoutingConfiguration.Route;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -88,15 +87,11 @@ public class RedisClusterClient extends BaseClient
     }
 
     @Override
-    public CompletableFuture<ClusterValue<Object>[]> exec(
-            @NonNull ClusterTransaction transaction, Route route) {
-        return commandManager
-                .submitNewCommand(transaction, Optional.ofNullable(route), this::handleArrayOrNullResponse)
-                .thenApply(
-                        objects ->
-                                Arrays.stream(objects)
-                                        .map(ClusterValue::of)
-                                        .<ClusterValue<Object>>toArray(ClusterValue[]::new));
+    public CompletableFuture<Object[]> exec(
+            @NonNull ClusterTransaction transaction, @NonNull Route route) {
+        assert route.isSingleNodeRoute() : "Multi-node routes are not supported for transaction";
+        return commandManager.submitNewCommand(
+                transaction, Optional.of(route), this::handleArrayOrNullResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
@@ -93,8 +93,8 @@ public interface GenericClusterCommands {
      * @see <a href="https://redis.io/topics/Transactions/">redis.io</a> for details on Redis
      *     Transactions.
      * @param transaction A {@link Transaction} object containing a list of commands to be executed.
-     * @param route A single-node the routing configuration for the transaction. The client will route
-     *     the transaction to the node defined by <code>route</code>.
+     * @param route A single-node routing configuration for the transaction. The client will route the
+     *     transaction to the node defined by <code>route</code>.
      * @return A list of results corresponding to the execution of each command in the transaction.
      * @remarks
      *     <ul>

--- a/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
@@ -93,8 +93,8 @@ public interface GenericClusterCommands {
      * @see <a href="https://redis.io/topics/Transactions/">redis.io</a> for details on Redis
      *     Transactions.
      * @param transaction A {@link Transaction} object containing a list of commands to be executed.
-     * @param route Specifies the routing configuration for the transaction. The client will route the
-     *     transaction to the nodes defined by <code>route</code>.
+     * @param route A single-node the routing configuration for the transaction. The client will route
+     *     the transaction to the node defined by <code>route</code>.
      * @return A list of results corresponding to the execution of each command in the transaction.
      * @remarks
      *     <ul>
@@ -107,10 +107,10 @@ public interface GenericClusterCommands {
      * @example
      *     <pre>{@code
      * ClusterTransaction transaction = new ClusterTransaction().ping().info();
-     * ClusterValue<Object>[] result = clusterClient.exec(transaction, RANDOM).get();
-     * assert ((String) result[0].getSingleValue()).equals("PONG");
-     * assert ((String) result[1].getSingleValue()).contains("# Stats");
+     * Object[] result = clusterClient.exec(transaction, RANDOM).get();
+     * assert ((String) result[0]).equals("PONG");
+     * assert ((String) result[1]).contains("# Stats");
      * }</pre>
      */
-    CompletableFuture<ClusterValue<Object>[]> exec(ClusterTransaction transaction, Route route);
+    CompletableFuture<Object[]> exec(ClusterTransaction transaction, Route route);
 }

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -6,7 +6,9 @@ import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleR
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_PRIMARIES;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -23,6 +25,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.Time;
 
+import glide.api.models.ClusterTransaction;
 import glide.api.models.ClusterValue;
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.configuration.RequestRoutingConfiguration.Route;
@@ -31,6 +34,7 @@ import glide.managers.ConnectionManager;
 import glide.managers.RedisExceptionCheckedFunction;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -147,6 +151,61 @@ public class RedisClusterClientTest {
                 RedisRequest.Builder command, RedisExceptionCheckedFunction<Response, T> responseHandler) {
             return CompletableFuture.supplyAsync(() -> responseHandler.apply(response));
         }
+    }
+
+    @SneakyThrows
+    @Test
+    public void exec_without_routing() {
+        // setup
+        Object[] value = new Object[] {"PONG", "PONG"};
+        ClusterTransaction transaction = new ClusterTransaction().ping().ping();
+
+        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Object[]>submitNewCommand(eq(transaction), eq(Optional.empty()), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Object[]> response = service.exec(transaction);
+        Object[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertArrayEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void exec_with_routing() {
+        // setup
+        Object[] value = new Object[] {"PONG", "PONG"};
+        ClusterTransaction transaction = new ClusterTransaction().ping().ping();
+        Route route = RANDOM;
+
+        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Object[]>submitNewCommand(eq(transaction), eq(Optional.of(route)), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Object[]> response = service.exec(transaction, route);
+        Object[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertArrayEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void exec_supports_only_single_node_route() {
+        var exception =
+                assertThrows(Throwable.class, () -> service.exec(new ClusterTransaction(), ALL_NODES));
+        assertEquals("Multi-node routes are not supported for transaction", exception.getMessage());
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -205,7 +205,7 @@ public class RedisClusterClientTest {
     public void exec_supports_only_single_node_route() {
         var exception =
                 assertThrows(Throwable.class, () -> service.exec(new ClusterTransaction(), ALL_NODES));
-        assertEquals("Multi-node routes are not supported for transaction", exception.getMessage());
+        assertEquals("Multi-node routes are not supported for exec()", exception.getMessage());
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -13,10 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import glide.TestConfiguration;
 import glide.api.RedisClusterClient;
 import glide.api.models.ClusterTransaction;
-import glide.api.models.ClusterValue;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -68,15 +66,10 @@ public class ClusterTransactionTests {
     @SneakyThrows
     public void info_simple_route_test() {
         ClusterTransaction transaction = new ClusterTransaction().info().info();
-        ClusterValue<Object>[] result =
-                clusterClient.exec(transaction, RANDOM).get(10, TimeUnit.SECONDS);
+        Object[] result = clusterClient.exec(transaction, RANDOM).get(10, TimeUnit.SECONDS);
 
-        // check single-value result
-        assertTrue(result[0].hasSingleData());
-        assertTrue(((String) result[0].getSingleValue()).contains("# Stats"));
-
-        assertTrue(result[1].hasSingleData());
-        assertTrue(((String) result[1].getSingleValue()).contains("# Stats"));
+        assertTrue(((String) result[0]).contains("# Stats"));
+        assertTrue(((String) result[1]).contains("# Stats"));
     }
 
     @SneakyThrows
@@ -85,12 +78,7 @@ public class ClusterTransactionTests {
         ClusterTransaction transaction = (ClusterTransaction) transactionTest(new ClusterTransaction());
         Object[] expectedResult = transactionTestResult();
 
-        ClusterValue<Object>[] clusterValues =
-                clusterClient.exec(transaction, RANDOM).get(10, TimeUnit.SECONDS);
-        Object[] results =
-                Arrays.stream(clusterValues)
-                        .map(v -> v.hasSingleData() ? v.getSingleValue() : v.getMultiValue())
-                        .toArray(Object[]::new);
+        Object[] results = clusterClient.exec(transaction, RANDOM).get(10, TimeUnit.SECONDS);
         assertArrayEquals(expectedResult, results);
     }
 }

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -66,7 +66,7 @@ public class ClusterTransactionTests {
     @SneakyThrows
     public void info_simple_route_test() {
         ClusterTransaction transaction = new ClusterTransaction().info().info();
-        Object[] result = clusterClient.exec(transaction, RANDOM).get(10, TimeUnit.SECONDS);
+        Object[] result = clusterClient.exec(transaction, RANDOM).get();
 
         assertTrue(((String) result[0]).contains("# Stats"));
         assertTrue(((String) result[1]).contains("# Stats"));
@@ -78,7 +78,7 @@ public class ClusterTransactionTests {
         ClusterTransaction transaction = (ClusterTransaction) transactionTest(new ClusterTransaction());
         Object[] expectedResult = transactionTestResult();
 
-        Object[] results = clusterClient.exec(transaction, RANDOM).get(10, TimeUnit.SECONDS);
+        Object[] results = clusterClient.exec(transaction, RANDOM).get();
         assertArrayEquals(expectedResult, results);
     }
 }


### PR DESCRIPTION
The `exec()` command (with a transaction as input argument) for cluster-clients must be routed to a single node.  Multi-node routes are not supported. 