### PR TITLE
Python: add HRANDFIELD command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Python: Added ZLEXCOUNT command ([#1305](https://github.com/aws/glide-for-redis/pull/1305))
 * Python: Added ZREMRANGEBYLEX command ([#1306](https://github.com/aws/glide-for-redis/pull/1306))
 * Python: Added LINSERT command ([#1304](https://github.com/aws/glide-for-redis/pull/1304))
+* Python: Added HRANDFIELD command (TODO: Add PR link)
 
 #### Fixes
 * Python: Fix typing error "‘type’ object is not subscriptable" ([#1203](https://github.com/aws/glide-for-redis/pull/1203))

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn convert_hrandfield() {
         assert!(matches!(
-            expected_type_for_cmd(redis::cmd("HRANDFIELD").arg("key").arg("1").arg("withvalues"),
+            expected_type_for_cmd(redis::cmd("HRANDFIELD").arg("key").arg("1").arg("withvalues")),
             Some(ExpectedReturnType::ArrayOfKeyValuePairs)
         ));
 
@@ -342,7 +342,7 @@ mod tests {
                     .unwrap();
         assert_eq!(two_dimensional_array, converted_two_dimensional_array);
 
-        let empty_array = Value::Array(vec![])
+        let empty_array = Value::Array(vec![]);
         let converted_empty_array =
            convert_to_expected_type(empty_array, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
                    .unwrap();
@@ -351,9 +351,9 @@ mod tests {
         let converted_nil_value =
            convert_to_expected_type(Value::Nil, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
                    .unwrap();
-        assert_eq!(Value::Nil, converted_nil_value)
+        assert_eq!(Value::Nil, converted_nil_value);
 
-        let array_of_doubles = Value::Array(vec![Value::Double(5.5)])
+        let array_of_doubles = Value::Array(vec![Value::Double(5.5)]);
         assert!(convert_to_expected_type(
             array_of_doubles,
             Some(ExpectedReturnType::ArrayOfKeyValuePairs)

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -177,11 +177,12 @@ pub(crate) fn convert_to_expected_type(
                 .into()),
         },
         ExpectedReturnType::ArrayOfKeyValuePairs => match value {
+            Value::Nil => Ok(value.clone()),
             Value::Array(ref array) if array.is_empty() || matches!(array[0], Value::Array(_)) => {
                 Ok(value)
             },
             Value::Array(ref array) if matches!(array[0], Value::BulkString(_)) => {
-                convert_flat_array_to_key_value_pairs(array.clone())
+                convert_flat_array_to_key_value_pairs(&array[..])
             },
             _ => Err((
                 ErrorKind::TypeError,
@@ -252,7 +253,7 @@ fn convert_flat_array_to_key_value_pairs(array: &[Value]) -> RedisResult<Value> 
 
     let mut result = Vec::new();
     for i in (0..array.len()).step_by(2) {
-        let pair = vec![array[i], array[i + 1]];
+        let pair = vec![array[i].clone(), array[i + 1].clone()];
         result.push(Value::Array(pair));
     }
     Ok(Value::Array(result))

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -323,34 +323,49 @@ mod tests {
     #[test]
     fn convert_hrandfield() {
         assert!(matches!(
-            expected_type_for_cmd(redis::cmd("HRANDFIELD").arg("key").arg("1").arg("withvalues")),
+            expected_type_for_cmd(
+                redis::cmd("HRANDFIELD")
+                    .arg("key")
+                    .arg("1")
+                    .arg("withvalues")
+            ),
             Some(ExpectedReturnType::ArrayOfKeyValuePairs)
         ));
 
         assert!(expected_type_for_cmd(redis::cmd("HRANDFIELD").arg("key").arg("1")).is_none());
         assert!(expected_type_for_cmd(redis::cmd("HRANDFIELD").arg("key")).is_none());
 
-        let flat_array = Value::Array(vec![Value::BulkString("key1"), Value::BulkString("value1"), Value::BulkString("key2"), Value::BulkString("value2")]);
-        let two_dimensional_array = Value::Array(vec![Value::Array(vec![Value::BulkString("key1"), Value::BulkString("key2")]), Value::Array(vec![Value::BulkString("key2"), Value::BulkString("value2")])]);
+        let flat_array = Value::Array(vec![
+            Value::BulkString("key1"),
+            Value::BulkString("value1"),
+            Value::BulkString("key2"),
+            Value::BulkString("value2"),
+        ]);
+        let two_dimensional_array = Value::Array(vec![
+            Value::Array(vec![Value::BulkString("key1"), Value::BulkString("key2")]),
+            Value::Array(vec![Value::BulkString("key2"), Value::BulkString("value2")]),
+        ]);
         let converted_flat_array =
             convert_to_expected_type(flat_array, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
                 .unwrap();
         assert_eq!(two_dimensional_array, converted_flat_array);
 
-        let converted_two_dimensional_array =
-            convert_to_expected_type(two_dimensional_array, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
-                    .unwrap();
+        let converted_two_dimensional_array = convert_to_expected_type(
+            two_dimensional_array,
+            Some(ExpectedReturnType::ArrayOfKeyValuePairs),
+        )
+        .unwrap();
         assert_eq!(two_dimensional_array, converted_two_dimensional_array);
 
         let empty_array = Value::Array(vec![]);
         let converted_empty_array =
-           convert_to_expected_type(empty_array, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
-                   .unwrap();
+            convert_to_expected_type(empty_array, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
+                .unwrap();
         assert_eq!(empty_array, converted_empty_array);
 
         let converted_nil_value =
-           convert_to_expected_type(Value::Nil, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
-                   .unwrap();
+            convert_to_expected_type(Value::Nil, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
+                .unwrap();
         assert_eq!(Value::Nil, converted_nil_value);
 
         let array_of_doubles = Value::Array(vec![Value::Double(5.5)]);

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -180,10 +180,10 @@ pub(crate) fn convert_to_expected_type(
             Value::Nil => Ok(value.clone()),
             Value::Array(ref array) if array.is_empty() || matches!(array[0], Value::Array(_)) => {
                 Ok(value)
-            },
+            }
             Value::Array(ref array) if matches!(array[0], Value::BulkString(_)) => {
                 convert_flat_array_to_key_value_pairs(&array[..])
-            },
+            }
             _ => Err((
                 ErrorKind::TypeError,
                 "Response couldn't be converted to an array of key-value pairs",

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -181,7 +181,9 @@ pub(crate) fn convert_to_expected_type(
             Value::Array(ref array) if array.is_empty() || matches!(array[0], Value::Array(_)) => {
                 Ok(value)
             }
-            Value::Array(array) if matches!(array[0], Value::BulkString(_) | Value::SimpleString(_)) => {
+            Value::Array(array)
+                if matches!(array[0], Value::BulkString(_) | Value::SimpleString(_)) =>
+            {
                 convert_flat_array_to_key_value_pairs(array)
             }
             _ => Err((
@@ -342,8 +344,14 @@ mod tests {
             Value::BulkString(b"value2".to_vec()),
         ]);
         let two_dimensional_array = Value::Array(vec![
-            Value::Array(vec![Value::BulkString(b"key1".to_vec()), Value::BulkString(b"value1".to_vec())]),
-            Value::Array(vec![Value::BulkString(b"key2".to_vec()), Value::BulkString(b"value2".to_vec())]),
+            Value::Array(vec![
+                Value::BulkString(b"key1".to_vec()),
+                Value::BulkString(b"value1".to_vec()),
+            ]),
+            Value::Array(vec![
+                Value::BulkString(b"key2".to_vec()),
+                Value::BulkString(b"value2".to_vec()),
+            ]),
         ]);
         let converted_flat_array =
             convert_to_expected_type(flat_array, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
@@ -358,9 +366,11 @@ mod tests {
         assert_eq!(two_dimensional_array, converted_two_dimensional_array);
 
         let empty_array = Value::Array(vec![]);
-        let converted_empty_array =
-            convert_to_expected_type(empty_array.clone(), Some(ExpectedReturnType::ArrayOfKeyValuePairs))
-                .unwrap();
+        let converted_empty_array = convert_to_expected_type(
+            empty_array.clone(),
+            Some(ExpectedReturnType::ArrayOfKeyValuePairs),
+        )
+        .unwrap();
         assert_eq!(empty_array, converted_empty_array);
 
         let converted_nil_value =

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -163,6 +163,7 @@ enum RequestType {
     GeoAdd = 121;
     GeoHash = 122;
     ObjectEncoding = 123;
+    HRandField = 124;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -131,6 +131,7 @@ pub enum RequestType {
     GeoAdd = 121,
     GeoHash = 122,
     ObjectEncoding = 123,
+    HRandField = 124,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -265,6 +266,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::GeoAdd => RequestType::GeoAdd,
             ProtobufRequestType::GeoHash => RequestType::GeoHash,
             ProtobufRequestType::ObjectEncoding => RequestType::ObjectEncoding,
+            ProtobufRequestType::HRandField => RequestType::HRandField,
         }
     }
 }
@@ -395,6 +397,7 @@ impl RequestType {
             RequestType::GeoAdd => Some(cmd("GEOADD")),
             RequestType::GeoHash => Some(cmd("GEOHASH")),
             RequestType::ObjectEncoding => Some(get_two_word_command("OBJECT", "ENCODING")),
+            RequestType::HRandField => Some(cmd("HRANDFIELD")),
         }
     }
 }

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -808,6 +808,86 @@ class CoreCommands(Protocol):
         """
         return cast(List[str], await self._execute_command(RequestType.Hkeys, [key]))
 
+    async def hrandfield(self, key: str) -> Optional[str]:
+        """
+        Returns a random field name from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+
+        Returns:
+            Optional[str]: A random field name from the hash stored at `key`.
+            If the hash does not exist or is empty, None will be returned.
+
+        Examples:
+            >>> await client.hrandfield("my_hash")
+                "field1"  # A random field name stored in the hash "my_hash".
+        """
+        return cast(
+            Optional[str], await self._execute_command(RequestType.HRandField, [key])
+        )
+
+    async def hrandfield_count(self, key: str, count: int) -> List[str]:
+        """
+        Retrieves random field names from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+            count (int): The number of field names to return.
+                If `count` is positive, returns unique elements.
+                If negative, allows for duplicates.
+
+        Returns:
+            List[str]: A list of random field names from the hash.
+            If the hash does not exist or is empty, the response will be an empty list.
+
+        Examples:
+            >>> await client.hrandfield_count("my_hash", -3)
+                ["field1", "field1", "field2"]  # Non-distinct, random field names stored in the hash "my_hash".
+            >>> await client.hrandfield_count("non_existing_hash", 3)
+                []  # Empty list
+        """
+        return cast(
+            List[str],
+            await self._execute_command(RequestType.HRandField, [key, str(count)]),
+        )
+
+    WITH_VALUES: str = "WITHVALUES"
+
+    async def hrandfield_count_withvalues(
+        self, key: str, count: int
+    ) -> List[List[str]]:
+        """
+        Retrieves random field names along with their values from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+            count (int): The number of field names to return.
+                If `count` is positive, returns unique elements.
+                If negative, allows for duplicates.
+
+        Returns:
+            List[List[str]]: A list of `[field_name, value]` lists, where `field_name` is a random field name from the
+            hash and `value` is the associated value of the field name.
+            If the hash does not exist or is empty, the response will be an empty list.
+
+        Examples:
+            >>> await client.hrandfield_count_withvalues("my_hash", -3)
+                [["field1", "value1"], ["field1", "value1"], ["field2", "value2"]]
+        """
+        return cast(
+            List[List[str]],
+            await self._execute_command(
+                RequestType.HRandField, [key, str(count), self.WITH_VALUES]
+            ),
+        )
+
     async def lpush(self, key: str, elements: List[str]) -> int:
         """
         Insert all the specified values at the head of the list stored at `key`.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -607,6 +607,62 @@ class BaseTransaction:
         """
         return self.append_command(RequestType.Hkeys, [key])
 
+    def hrandfield(self: TTransaction, key: str) -> TTransaction:
+        """
+        Returns a random field name from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+
+        Command response:
+            Optional[str]: A random field name from the hash stored at `key`.
+            If the hash does not exist or is empty, None will be returned.
+        """
+        return self.append_command(RequestType.HRandField, [key])
+
+    def hrandfield_count(self: TTransaction, key: str, count: int) -> TTransaction:
+        """
+        Retrieves random field names from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+            count (int): The number of field names to return.
+                If `count` is positive, returns unique elements.
+                If negative, allows for duplicates.
+
+        Command response:
+            List[str]: A list of random field names from the hash.
+            If the hash does not exist or is empty, the response will be an empty list.
+        """
+        return self.append_command(RequestType.HRandField, [key, str(count)])
+
+    def hrandfield_count_withvalues(
+        self: TTransaction, key: str, count: int
+    ) -> TTransaction:
+        """
+        Retrieves random field names along with their values from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+            count (int): The number of field names to return.
+                If `count` is positive, returns unique elements.
+                If negative, allows for duplicates.
+
+        Command response:
+            List[List[str]]: A list of `[field_name, value]` lists, where `field_name` is a random field name from the
+            hash and `value` is the associated value of the field name.
+            If the hash does not exist or is empty, the response will be an empty list.
+        """
+        return self.append_command(
+            RequestType.HRandField, [key, str(count), "WITHVALUES"]
+        )
+
     def lpush(self: TTransaction, key: str, elements: List[str]) -> TTransaction:
         """
         Insert all the specified values at the head of the list stored at `key`.

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -799,6 +799,84 @@ class TestCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_hrandfield(self, redis_client: TRedisClient):
+        key = get_random_string(10)
+        key2 = get_random_string(5)
+        field = get_random_string(5)
+        field2 = get_random_string(5)
+        field_value_map = {field: "value", field2: "value2"}
+
+        assert await redis_client.hset(key, field_value_map) == 2
+        assert await redis_client.hrandfield(key) in [field, field2]
+        assert await redis_client.hrandfield("non_existing_key") is None
+
+        assert await redis_client.set(key2, "value") == OK
+        with pytest.raises(RequestError):
+            await redis_client.hrandfield(key2)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_hrandfield_count(self, redis_client: TRedisClient):
+        key = get_random_string(10)
+        key2 = get_random_string(5)
+        field = get_random_string(5)
+        field2 = get_random_string(5)
+        field_value_map = {field: "value", field2: "value2"}
+
+        assert await redis_client.hset(key, field_value_map) == 2
+        # Unique values are expected as count is positive
+        rand_fields = await redis_client.hrandfield_count(key, 4)
+        assert len(rand_fields) == 2
+        assert set(rand_fields) == {field, field2}
+
+        # Duplicate values are expected as count is negative
+        rand_fields = await redis_client.hrandfield_count(key, -4)
+        assert len(rand_fields) == 4
+        for rand_field in rand_fields:
+            assert rand_field in [field, field2]
+
+        assert await redis_client.hrandfield_count(key, 0) == []
+        assert await redis_client.hrandfield_count("non_existing_key", 4) == []
+
+        assert await redis_client.set(key2, "value") == OK
+        with pytest.raises(RequestError):
+            await redis_client.hrandfield_count(key2, 5)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_hrandfield_count_withvalues(self, redis_client: TRedisClient):
+        key = get_random_string(10)
+        key2 = get_random_string(5)
+        field = get_random_string(5)
+        field2 = get_random_string(5)
+        field_value_map = {field: "value", field2: "value2"}
+
+        assert await redis_client.hset(key, field_value_map) == 2
+        # Unique values are expected as count is positive
+        rand_fields_with_values = await redis_client.hrandfield_count_withvalues(key, 4)
+        assert len(rand_fields_with_values) == 2
+        for field_with_value in rand_fields_with_values:
+            assert field_with_value in [[field, "value"], [field2, "value2"]]
+
+        # Duplicate values are expected as count is negative
+        rand_fields_with_values = await redis_client.hrandfield_count_withvalues(
+            key, -4
+        )
+        assert len(rand_fields_with_values) == 4
+        for field_with_value in rand_fields_with_values:
+            assert field_with_value in [[field, "value"], [field2, "value2"]]
+
+        assert await redis_client.hrandfield_count_withvalues(key, 0) == []
+        assert (
+            await redis_client.hrandfield_count_withvalues("non_existing_key", 4) == []
+        )
+
+        assert await redis_client.set(key2, "value") == OK
+        with pytest.raises(RequestError):
+            await redis_client.hrandfield_count_withvalues(key2, 5)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_lpush_lpop_lrange(self, redis_client: TRedisClient):
         key = get_random_string(10)
         value_list = ["value4", "value3", "value2", "value1"]

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -129,6 +129,15 @@ async def transaction_test(
     transaction.hdel(key4, [key, key2])
     args.append(2)
 
+    transaction.hset(key9, {key: value})
+    args.append(1)
+    transaction.hrandfield(key9)
+    args.append(key)
+    transaction.hrandfield_count(key9, 1)
+    args.append([key])
+    transaction.hrandfield_count_withvalues(key9, 1)
+    args.append([[key, value]])
+
     transaction.client_getname()
     args.append(None)
 

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -38,7 +38,7 @@ async def transaction_test(
     key7 = "{{{}}}:{}".format(keyslot, get_random_string(3))
     key8 = "{{{}}}:{}".format(keyslot, get_random_string(3))
     key9 = "{{{}}}:{}".format(keyslot, get_random_string(3))
-    key10 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # list
+    key10 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # hash
 
     value = datetime.now(timezone.utc).strftime("%m/%d/%Y, %H:%M:%S")
     value2 = get_random_string(5)
@@ -129,13 +129,13 @@ async def transaction_test(
     transaction.hdel(key4, [key, key2])
     args.append(2)
 
-    transaction.hset(key9, {key: value})
+    transaction.hset(key10, {key: value})
     args.append(1)
-    transaction.hrandfield(key9)
+    transaction.hrandfield(key10)
     args.append(key)
-    transaction.hrandfield_count(key9, 1)
+    transaction.hrandfield_count(key10, 1)
     args.append([key])
-    transaction.hrandfield_count_withvalues(key9, 1)
+    transaction.hrandfield_count_withvalues(key10, 1)
     args.append([[key, value]])
 
     transaction.client_getname()


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Add `HRANDFIELD` command: https://redis.io/commands/hrandfield/
- Includes value conversion: 
  - RESP2 returns a flat array of BulkString values, where even-positioned elements are keys and odd-positioned elements are values. RESP3 returns an array of array of BulkString values (in other words, a 2D-array where the inner arrays are key-value pairs). The value conversion converts the RESP2 responses to the RESP3 format.
  - Note that the returned type is a List instead of a Dict because the response may contain duplicates if the user passes in a negative `count` argument

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
