### PR TITLE
Java: Add `Zunion` command. (Sorted Set Group)

### DIFF
--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -282,35 +282,99 @@ mod tests {
     fn convert_zunion_only_if_withsocres_is_included() {
         // Test ZUNION without options
         assert!(matches!(
-            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WITHSCORES")),
+            expected_type_for_cmd(
+                redis::cmd("ZUNION")
+                    .arg("2")
+                    .arg("set1")
+                    .arg("set2")
+                    .arg("WITHSCORES")
+            ),
             Some(ExpectedReturnType::MapOfStringToDouble)
         ));
 
-        assert!(expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2")).is_none());
+        assert!(
+            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2")).is_none()
+        );
 
         // Test ZUNION with Weights
         assert!(matches!(
-            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WEIGHTS").arg("1").arg("2").arg("WITHSCORES")),
+            expected_type_for_cmd(
+                redis::cmd("ZUNION")
+                    .arg("2")
+                    .arg("set1")
+                    .arg("set2")
+                    .arg("WEIGHTS")
+                    .arg("1")
+                    .arg("2")
+                    .arg("WITHSCORES")
+            ),
             Some(ExpectedReturnType::MapOfStringToDouble)
         ));
 
-        assert!(expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WEIGHTS").arg("1").arg("2")).is_none());
+        assert!(expected_type_for_cmd(
+            redis::cmd("ZUNION")
+                .arg("2")
+                .arg("set1")
+                .arg("set2")
+                .arg("WEIGHTS")
+                .arg("1")
+                .arg("2")
+        )
+        .is_none());
 
         // Test ZUNION with Aggregate
         assert!(matches!(
-            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("AGGREGATE").arg("MAX").arg("WITHSCORES")),
+            expected_type_for_cmd(
+                redis::cmd("ZUNION")
+                    .arg("2")
+                    .arg("set1")
+                    .arg("set2")
+                    .arg("AGGREGATE")
+                    .arg("MAX")
+                    .arg("WITHSCORES")
+            ),
             Some(ExpectedReturnType::MapOfStringToDouble)
         ));
 
-        assert!(expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("AGGREGATE").arg("MAX")).is_none());
+        assert!(expected_type_for_cmd(
+            redis::cmd("ZUNION")
+                .arg("2")
+                .arg("set1")
+                .arg("set2")
+                .arg("AGGREGATE")
+                .arg("MAX")
+        )
+        .is_none());
 
         // Test ZUNION with Weights and Aggregate
         assert!(matches!(
-            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WEIGHTS").arg("1").arg("2").arg("AGGREGATE").arg("MAX").arg("WITHSCORES")),
+            expected_type_for_cmd(
+                redis::cmd("ZUNION")
+                    .arg("2")
+                    .arg("set1")
+                    .arg("set2")
+                    .arg("WEIGHTS")
+                    .arg("1")
+                    .arg("2")
+                    .arg("AGGREGATE")
+                    .arg("MAX")
+                    .arg("WITHSCORES")
+            ),
             Some(ExpectedReturnType::MapOfStringToDouble)
         ));
 
-        assert!(expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WEIGHTS").arg("1").arg("2").arg("AGGREGATE").arg("MAX")).is_none());
+        assert!(expected_type_for_cmd(
+            redis::cmd("ZUNION")
+                .arg("2")
+                .arg("set1")
+                .arg("set2")
+                .arg("WEIGHTS")
+                .arg("1")
+                .arg("2")
+                .arg("AGGREGATE")
+                .arg("MAX")
+        )
+        .is_none());
     }
 
     #[test]

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn convert_zunion_only_if_withsocres_is_included() {
+    fn convert_zunion_only_if_withscores_is_included() {
         // Test ZUNION without options
         assert!(matches!(
             expected_type_for_cmd(

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -227,7 +227,7 @@ pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType> {
         b"ZADD" => cmd
             .position(b"INCR")
             .map(|_| ExpectedReturnType::DoubleOrNull),
-        b"ZRANGE" | b"ZDIFF" => cmd
+        b"ZRANGE" | b"ZDIFF" | b"ZUNION" => cmd
             .position(b"WITHSCORES")
             .map(|_| ExpectedReturnType::MapOfStringToDouble),
         b"ZRANK" | b"ZREVRANK" => cmd
@@ -276,6 +276,41 @@ mod tests {
         ));
 
         assert!(expected_type_for_cmd(redis::cmd("ZDIFF").arg("1")).is_none());
+    }
+
+    #[test]
+    fn convert_zunion_only_if_withsocres_is_included() {
+        // Test ZUNION without options
+        assert!(matches!(
+            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WITHSCORES")),
+            Some(ExpectedReturnType::MapOfStringToDouble)
+        ));
+
+        assert!(expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2")).is_none());
+
+        // Test ZUNION with Weights
+        assert!(matches!(
+            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WEIGHTS").arg("1").arg("2").arg("WITHSCORES")),
+            Some(ExpectedReturnType::MapOfStringToDouble)
+        ));
+
+        assert!(expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WEIGHTS").arg("1").arg("2")).is_none());
+
+        // Test ZUNION with Aggregate
+        assert!(matches!(
+            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("AGGREGATE").arg("MAX").arg("WITHSCORES")),
+            Some(ExpectedReturnType::MapOfStringToDouble)
+        ));
+
+        assert!(expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("AGGREGATE").arg("MAX")).is_none());
+
+        // Test ZUNION with Weights and Aggregate
+        assert!(matches!(
+            expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WEIGHTS").arg("1").arg("2").arg("AGGREGATE").arg("MAX").arg("WITHSCORES")),
+            Some(ExpectedReturnType::MapOfStringToDouble)
+        ));
+
+        assert!(expected_type_for_cmd(redis::cmd("ZUNION").arg("2").arg("set1").arg("set2").arg("WEIGHTS").arg("1").arg("2").arg("AGGREGATE").arg("MAX")).is_none());
     }
 
     #[test]

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -149,6 +149,7 @@ enum RequestType {
     ZDiffStore = 106;
     SetRange = 107;
     ZRemRangeByLex = 108;
+    ZUnion = 110;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -117,6 +117,7 @@ pub enum RequestType {
     ZDiffStore = 106,
     SetRange = 107,
     ZRemRangeByLex = 108,
+    ZUnion = 110,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -237,6 +238,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::ZDiffStore => RequestType::ZDiffStore,
             ProtobufRequestType::SetRange => RequestType::SetRange,
             ProtobufRequestType::ZRemRangeByLex => RequestType::ZRemRangeByLex,
+            ProtobufRequestType::ZUnion => RequestType::ZUnion,
         }
     }
 }
@@ -353,6 +355,7 @@ impl RequestType {
             RequestType::ZDiffStore => Some(cmd("ZDIFFSTORE")),
             RequestType::SetRange => Some(cmd("SETRANGE")),
             RequestType::ZRemRangeByLex => Some(cmd("ZREMRANGEBYLEX")),
+            RequestType::ZUnion => Some(cmd("ZUNION")),
         }
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -70,6 +70,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.ZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.ZRemRangeByLex;
 import static redis_request.RedisRequestOuterClass.RequestType.ZRemRangeByRank;
 import static redis_request.RedisRequestOuterClass.RequestType.ZScore;
+import static redis_request.RedisRequestOuterClass.RequestType.ZUnion;
 import static redis_request.RedisRequestOuterClass.RequestType.Zadd;
 import static redis_request.RedisRequestOuterClass.RequestType.Zcard;
 import static redis_request.RedisRequestOuterClass.RequestType.Zcount;
@@ -96,6 +97,7 @@ import glide.api.models.commands.RangeOptions.ScoredRangeQuery;
 import glide.api.models.commands.ScriptOptions;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.StreamAddOptions;
+import glide.api.models.commands.WeightAggregateOptions;
 import glide.api.models.commands.ZaddOptions;
 import glide.api.models.configuration.BaseClientConfiguration;
 import glide.api.models.exceptions.RedisException;
@@ -797,6 +799,37 @@ public abstract class BaseClient
                 ArrayUtils.addAll(
                         ArrayUtils.addFirst(options.toArgs(), key), convertMapToKeyValueStringArray(values));
         return commandManager.submitNewCommand(XAdd, arguments, this::handleStringOrNullResponse);
+    }
+
+    @Override
+    public CompletableFuture<String[]> zunion(
+            @NonNull String[] keys, @NonNull WeightAggregateOptions options) {
+        String[] arguments =
+                concatenateArrays(new String[] {Integer.toString(keys.length)}, keys, options.toArgs());
+        return commandManager.submitNewCommand(
+                ZUnion, arguments, response -> castArray(handleArrayResponse(response), String.class));
+    }
+
+    @Override
+    public CompletableFuture<String[]> zunion(@NonNull String[] keys) {
+        return zunion(keys, WeightAggregateOptions.builder().build());
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Double>> zunionWithScores(
+            @NonNull String[] keys, @NonNull WeightAggregateOptions options) {
+        String[] arguments =
+                concatenateArrays(
+                        new String[] {Integer.toString(keys.length)},
+                        keys,
+                        options.toArgs(),
+                        new String[] {WITH_SCORES_REDIS_API});
+        return commandManager.submitNewCommand(ZUnion, arguments, this::handleMapResponse);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Double>> zunionWithScores(@NonNull String[] keys) {
+        return zunionWithScores(keys, WeightAggregateOptions.builder().build());
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
@@ -616,7 +616,8 @@ public interface SortedSetBaseCommands {
     CompletableFuture<Long> zremrangebylex(String key, LexRange minLex, LexRange maxLex);
 
     /**
-     * Returns the union of members from sorted sets specified by the given <code>keys</code>.
+     * Returns the union of members from sorted sets specified by the given <code>keys</code>.<br>
+     * To get the elements with their scores, see {@link #zunionWithScores}.
      *
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keys The keys of sorted sets.
@@ -629,7 +630,7 @@ public interface SortedSetBaseCommands {
      *             .aggregate(Aggregate.MAX)
      *             .weights(List.of(1.0, 2.0))
      *             .build();
-     * String[] payload = client.zunionstore("newSortedSet", new String[] {"mySortedSet1", "mySortedSet2"}, options).get()
+     * String[] payload = client.zunion(new String[] {"mySortedSet1", "mySortedSet2"}, options).get()
      * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
      * }</pre>
      */
@@ -637,15 +638,16 @@ public interface SortedSetBaseCommands {
 
     /**
      * Returns the union of members from sorted sets specified by the given <code>keys</code>.<br>
-     * To perform a zunion operation while specifying custom weights and aggregation settings, use
-     * {@link #zunion(String[], WeightAggregateOptions)}
+     * To get the elements with their scores, see {@link #zunionWithScores}.<br>
+     * To perform a <code>zunion</code> operation while specifying custom weights and aggregation
+     * settings, use {@link #zunion(String[], WeightAggregateOptions)}
      *
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keys The keys of sorted sets.
      * @return The resulting sorted set from the union.
      * @example
      *     <pre>{@code
-     * String[] payload = client.zunionstore("newSortedSet", new String[] {"mySortedSet1", "mySortedSet2"}).get()
+     * String[] payload = client.zunion(new String[] {"mySortedSet1", "mySortedSet2"}).get()
      * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
      * }</pre>
      */
@@ -666,7 +668,7 @@ public interface SortedSetBaseCommands {
      *             .aggregate(Aggregate.MAX)
      *             .weights(List.of(1.0, 2.0))
      *             .build();
-     * Map<String, Double> payload = client.zunionstoreWithScores("newSortedSet", new String[] {"mySortedSet1", "mySortedSet2"}, options).get()
+     * Map<String, Double> payload = client.zunionWithScores(new String[] {"mySortedSet1", "mySortedSet2"}, options).get()
      * assert payload.equals(Map.of("elem1", 1.0, "elem2", 2.0, "elem3", 3.0));
      * }</pre>
      */
@@ -676,15 +678,15 @@ public interface SortedSetBaseCommands {
     /**
      * Returns the union of members and their scores from sorted sets specified by the given <code>
      * keys</code>.<br>
-     * To perform a zunionWithScores operation while specifying custom weights and aggregation
-     * settings, use {@link #zunionWithScores(String[], WeightAggregateOptions)}
+     * To perform a <code>zunionWithScores</code> operation while specifying custom weights and
+     * aggregation settings, use {@link #zunionWithScores(String[], WeightAggregateOptions)}
      *
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keys The keys of sorted sets.
      * @return The resulting sorted set from the union with their scores.
      * @example
      *     <pre>{@code
-     * Map<String, Double> payload = client.zunionstoreWithScores("newSortedSet", new String[] {"mySortedSet1", "mySortedSet2"}).get()
+     * Map<String, Double> payload = client.zunionWithScores(new String[] {"mySortedSet1", "mySortedSet2"}).get()
      * assert payload.equals(Map.of("elem1", 1.0, "elem2", 2.0, "elem3", 3.0));
      * }</pre>
      */

--- a/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
@@ -12,6 +12,7 @@ import glide.api.models.commands.RangeOptions.RangeQuery;
 import glide.api.models.commands.RangeOptions.ScoreBoundary;
 import glide.api.models.commands.RangeOptions.ScoreRange;
 import glide.api.models.commands.RangeOptions.ScoredRangeQuery;
+import glide.api.models.commands.WeightAggregateOptions;
 import glide.api.models.commands.ZaddOptions;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -613,4 +614,79 @@ public interface SortedSetBaseCommands {
      * }</pre>
      */
     CompletableFuture<Long> zremrangebylex(String key, LexRange minLex, LexRange maxLex);
+
+    /**
+     * Returns the union of members from sorted sets specified by the given <code>keys</code>.
+     *
+     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
+     * @param keys The keys of sorted sets.
+     * @param options Weight and Aggregate options.
+     * @return The resulting sorted set from the union.
+     * @example
+     *     <pre>{@code
+     * WeightAggregateOptions options =
+     *     WeightAggregateOptions.builder()
+     *             .aggregate(Aggregate.MAX)
+     *             .weights(List.of(1.0, 2.0))
+     *             .build();
+     * String[] payload = client.zunionstore("newSortedSet", new String[] {"mySortedSet1", "mySortedSet2"}, options).get()
+     * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
+     * }</pre>
+     */
+    CompletableFuture<String[]> zunion(String[] keys, WeightAggregateOptions options);
+
+    /**
+     * Returns the union of members from sorted sets specified by the given <code>keys</code>.<br>
+     * To perform a zunion operation while specifying custom weights and aggregation settings, use
+     * {@link #zunion(String[], WeightAggregateOptions)}
+     *
+     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
+     * @param keys The keys of sorted sets.
+     * @return The resulting sorted set from the union.
+     * @example
+     *     <pre>{@code
+     * String[] payload = client.zunionstore("newSortedSet", new String[] {"mySortedSet1", "mySortedSet2"}).get()
+     * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
+     * }</pre>
+     */
+    CompletableFuture<String[]> zunion(String[] keys);
+
+    /**
+     * Returns the union of members and their scores from sorted sets specified by the given <code>
+     * keys</code>.
+     *
+     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
+     * @param keys The keys of sorted sets.
+     * @param options Weight and Aggregate options.
+     * @return The resulting sorted set from the union with their scores.
+     * @example
+     *     <pre>{@code
+     * WeightAggregateOptions options =
+     *     WeightAggregateOptions.builder()
+     *             .aggregate(Aggregate.MAX)
+     *             .weights(List.of(1.0, 2.0))
+     *             .build();
+     * Map<String, Double> payload = client.zunionstoreWithScores("newSortedSet", new String[] {"mySortedSet1", "mySortedSet2"}, options).get()
+     * assert payload.equals(Map.of("elem1", 1.0, "elem2", 2.0, "elem3", 3.0));
+     * }</pre>
+     */
+    CompletableFuture<Map<String, Double>> zunionWithScores(
+            String[] keys, WeightAggregateOptions options);
+
+    /**
+     * Returns the union of members and their scores from sorted sets specified by the given <code>
+     * keys</code>.<br>
+     * To perform a zunionWithScores operation while specifying custom weights and aggregation
+     * settings, use {@link #zunionWithScores(String[], WeightAggregateOptions)}
+     *
+     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
+     * @param keys The keys of sorted sets.
+     * @return The resulting sorted set from the union with their scores.
+     * @example
+     *     <pre>{@code
+     * Map<String, Double> payload = client.zunionstoreWithScores("newSortedSet", new String[] {"mySortedSet1", "mySortedSet2"}).get()
+     * assert payload.equals(Map.of("elem1", 1.0, "elem2", 2.0, "elem3", 3.0));
+     * }</pre>
+     */
+    CompletableFuture<Map<String, Double>> zunionWithScores(String[] keys);
 }

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -82,6 +82,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.ZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.ZRemRangeByLex;
 import static redis_request.RedisRequestOuterClass.RequestType.ZRemRangeByRank;
 import static redis_request.RedisRequestOuterClass.RequestType.ZScore;
+import static redis_request.RedisRequestOuterClass.RequestType.ZUnion;
 import static redis_request.RedisRequestOuterClass.RequestType.Zadd;
 import static redis_request.RedisRequestOuterClass.RequestType.Zcard;
 import static redis_request.RedisRequestOuterClass.RequestType.Zcount;
@@ -109,6 +110,7 @@ import glide.api.models.commands.SetOptions.ConditionalSet;
 import glide.api.models.commands.SetOptions.SetOptionsBuilder;
 import glide.api.models.commands.StreamAddOptions;
 import glide.api.models.commands.StreamAddOptions.StreamAddOptionsBuilder;
+import glide.api.models.commands.WeightAggregateOptions;
 import glide.api.models.commands.ZaddOptions;
 import java.util.Map;
 import lombok.Getter;
@@ -1645,6 +1647,71 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
         ArgsArray commandArgs = buildArgs(key, minLex.toArgs(), maxLex.toArgs());
         protobufTransaction.addCommands(buildCommand(ZRemRangeByLex, commandArgs));
         return getThis();
+    }
+
+    /**
+     * Returns the union of members from sorted sets specified by the given <code>keys</code>.
+     *
+     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
+     * @param keys The keys of sorted sets.
+     * @param options Weight and Aggregate options.
+     * @return Command Response - The resulting sorted set from the union.
+     */
+    public T zunion(@NonNull String[] keys, @NonNull WeightAggregateOptions options) {
+        ArgsArray commandArgs =
+                buildArgs(
+                        concatenateArrays(
+                                new String[] {Integer.toString(keys.length)}, keys, options.toArgs()));
+        protobufTransaction.addCommands(buildCommand(ZUnion, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns the union of members from sorted sets specified by the given <code>keys</code>.<br>
+     * To perform a zunion operation while specifying custom weights and aggregation settings, use
+     * {@link #zunion(String[], WeightAggregateOptions)}
+     *
+     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
+     * @param keys The keys of sorted sets.
+     * @return Command Response - The resulting sorted set from the union.
+     */
+    public T zunion(@NonNull String[] keys) {
+        return zunion(keys, WeightAggregateOptions.builder().build());
+    }
+
+    /**
+     * Returns the union of members and their scores from sorted sets specified by the given <code>
+     * keys</code>.
+     *
+     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
+     * @param keys The keys of sorted sets.
+     * @param options Weight and Aggregate options.
+     * @return Command Response - The resulting sorted set from the union with their scores.
+     */
+    public T zunionWithScores(@NonNull String[] keys, @NonNull WeightAggregateOptions options) {
+        ArgsArray commandArgs =
+                buildArgs(
+                        concatenateArrays(
+                                new String[] {Integer.toString(keys.length)},
+                                keys,
+                                options.toArgs(),
+                                new String[] {WITH_SCORES_REDIS_API}));
+        protobufTransaction.addCommands(buildCommand(ZUnion, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns the union of members and their scores from sorted sets specified by the given <code>
+     * keys</code>.<br>
+     * To perform a zunionWithScores operation while specifying custom weights and aggregation
+     * settings, use {@link #zunionWithScores(String[], WeightAggregateOptions)}
+     *
+     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
+     * @param keys The keys of sorted sets.
+     * @return Command Response - The resulting sorted set from the union with their scores.
+     */
+    public T zunionWithScores(@NonNull String[] keys) {
+        return zunionWithScores(keys, WeightAggregateOptions.builder().build());
     }
 
     /**

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -1650,7 +1650,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Returns the union of members from sorted sets specified by the given <code>keys</code>.
+     * Returns the union of members from sorted sets specified by the given <code>keys</code>.<br>
+     * To get the elements with their scores, see {@link #zunionWithScores}.
      *
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keys The keys of sorted sets.
@@ -1668,8 +1669,9 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
 
     /**
      * Returns the union of members from sorted sets specified by the given <code>keys</code>.<br>
-     * To perform a zunion operation while specifying custom weights and aggregation settings, use
-     * {@link #zunion(String[], WeightAggregateOptions)}
+     * To get the elements with their scores, see {@link #zunionWithScores}.<br>
+     * To perform a <code>zunion</code> operation while specifying custom weights and aggregation
+     * settings, use {@link #zunion(String[], WeightAggregateOptions)}
      *
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keys The keys of sorted sets.
@@ -1703,8 +1705,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the union of members and their scores from sorted sets specified by the given <code>
      * keys</code>.<br>
-     * To perform a zunionWithScores operation while specifying custom weights and aggregation
-     * settings, use {@link #zunionWithScores(String[], WeightAggregateOptions)}
+     * To perform a <code>zunionWithScores</code> operation while specifying custom weights and
+     * aggregation settings, use {@link #zunionWithScores(String[], WeightAggregateOptions)}
      *
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keys The keys of sorted sets.

--- a/java/client/src/main/java/glide/api/models/commands/WeightAggregateOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/WeightAggregateOptions.java
@@ -1,0 +1,67 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.commands;
+
+import glide.api.commands.SortedSetBaseCommands;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Singular;
+
+/**
+ * Optional arguments to {@link SortedSetBaseCommands#zunion}
+ *
+ * @see <a href="https://redis.io/commands/zunionstore/">redis.io</a> for more details.
+ */
+@Builder
+public final class WeightAggregateOptions {
+    public static final String WEIGHTS_REDIS_API = "WEIGHTS";
+    public static final String AGGREGATE_REDIS_API = "AGGREGATE";
+
+    /**
+     * Represents multiplication factors for each sorted set, ready for aggregation. Each
+     * multiplication factor corresponds one-to-one with the sets. The score of every element in these
+     * sets is multiplied by its associated factor before aggregation.
+     */
+    @Singular private final List<Double> weights;
+
+    /**
+     * Option for the method of aggregating scores from multiple sets. This option defaults to SUM if
+     * not specified.
+     */
+    private final Aggregate aggregate;
+
+    /**
+     * Option for the method of aggregating scores from multiple sets. This option defaults to SUM if
+     * not specified.
+     */
+    public enum Aggregate {
+        /** Aggregates by summing the scores of each element across sets. */
+        SUM,
+        /** Aggregates by selecting the minimum score for each element across sets. */
+        MIN,
+        /** Aggregates by selecting the maximum score for each element across sets. */
+        MAX;
+    }
+
+    /**
+     * Converts WeightAggregateOptions into a String[].
+     *
+     * @return String[]
+     */
+    public String[] toArgs() {
+        List<String> optionArgs = new ArrayList<>();
+
+        if (!weights.isEmpty()) {
+            optionArgs.add(WEIGHTS_REDIS_API);
+            optionArgs.addAll(
+                    weights.stream().map(element -> Double.toString(element)).collect(Collectors.toList()));
+        }
+
+        if (aggregate != null) {
+            optionArgs.addAll(List.of(AGGREGATE_REDIS_API, aggregate.toString()));
+        }
+
+        return optionArgs.toArray(new String[0]);
+    }
+}

--- a/java/client/src/main/java/glide/api/models/commands/WeightAggregateOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/WeightAggregateOptions.java
@@ -9,9 +9,10 @@ import lombok.Builder;
 import lombok.Singular;
 
 /**
- * Optional arguments to {@link SortedSetBaseCommands#zunion}
+ * Optional arguments to {@link SortedSetBaseCommands#zunion(String[], WeightAggregateOptions)}, and
+ * {@link SortedSetBaseCommands#zunionWithScores(String[], WeightAggregateOptions)}.
  *
- * @see <a href="https://redis.io/commands/zunionstore/">redis.io</a> for more details.
+ * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
  */
 @Builder
 public final class WeightAggregateOptions {

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -14,6 +14,8 @@ import static glide.api.models.commands.StreamAddOptions.TRIM_LIMIT_REDIS_API;
 import static glide.api.models.commands.StreamAddOptions.TRIM_MAXLEN_REDIS_API;
 import static glide.api.models.commands.StreamAddOptions.TRIM_MINID_REDIS_API;
 import static glide.api.models.commands.StreamAddOptions.TRIM_NOT_EXACT_REDIS_API;
+import static glide.api.models.commands.WeightAggregateOptions.AGGREGATE_REDIS_API;
+import static glide.api.models.commands.WeightAggregateOptions.WEIGHTS_REDIS_API;
 import static glide.utils.ArrayTransformUtils.concatenateArrays;
 import static glide.utils.ArrayTransformUtils.convertMapToKeyValueStringArray;
 import static glide.utils.ArrayTransformUtils.convertMapToValueKeyStringArray;
@@ -103,6 +105,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.ZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.ZRemRangeByLex;
 import static redis_request.RedisRequestOuterClass.RequestType.ZRemRangeByRank;
 import static redis_request.RedisRequestOuterClass.RequestType.ZScore;
+import static redis_request.RedisRequestOuterClass.RequestType.ZUnion;
 import static redis_request.RedisRequestOuterClass.RequestType.Zadd;
 import static redis_request.RedisRequestOuterClass.RequestType.Zcard;
 import static redis_request.RedisRequestOuterClass.RequestType.Zcount;
@@ -126,6 +129,8 @@ import glide.api.models.commands.ScriptOptions;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.SetOptions.Expiry;
 import glide.api.models.commands.StreamAddOptions;
+import glide.api.models.commands.WeightAggregateOptions;
+import glide.api.models.commands.WeightAggregateOptions.Aggregate;
 import glide.api.models.commands.ZaddOptions;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
@@ -2500,6 +2505,128 @@ public class RedisClientTest {
         CompletableFuture<Long> response =
                 service.zremrangebylex(key, InfLexBound.NEGATIVE_INFINITY, new LexBoundary("z", true));
         Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void zunion_returns_success() {
+        // setup
+        String[] keys = new String[] {"key1", "key2"};
+        String[] arguments = new String[] {Integer.toString(keys.length), "key1", "key2"};
+        String[] value = new String[] {"elem1", "elem2"};
+
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<String[]>submitNewCommand(eq(ZUnion), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String[]> response = service.zunion(keys);
+        String[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void zunion_with_options_returns_success() {
+        // setup
+        String[] keys = new String[] {"key1", "key2"};
+        WeightAggregateOptions options =
+                WeightAggregateOptions.builder().weight(10.0).weight(20.0).aggregate(Aggregate.MIN).build();
+        String[] arguments =
+                new String[] {
+                    Integer.toString(keys.length),
+                    "key1",
+                    "key2",
+                    WEIGHTS_REDIS_API,
+                    "10.0",
+                    "20.0",
+                    AGGREGATE_REDIS_API,
+                    Aggregate.MIN.toString()
+                };
+        String[] value = new String[] {"elem1", "elem2"};
+
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<String[]>submitNewCommand(eq(ZUnion), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String[]> response = service.zunion(keys, options);
+        String[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void zunionWithScores_returns_success() {
+        // setup
+        String[] keys = new String[] {"key1", "key2"};
+        String[] arguments =
+                new String[] {Integer.toString(keys.length), "key1", "key2", WITH_SCORES_REDIS_API};
+        Map<String, Double> value = Map.of("elem1", 1.0, "elem2", 2.0);
+
+        CompletableFuture<Map<String, Double>> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Map<String, Double>>submitNewCommand(eq(ZUnion), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<String, Double>> response = service.zunionWithScores(keys);
+        Map<String, Double> payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void zunionWithScores_with_options_returns_success() {
+        // setup
+        String[] keys = new String[] {"key1", "key2"};
+        WeightAggregateOptions options =
+                WeightAggregateOptions.builder().weight(10.0).weight(20.0).aggregate(Aggregate.MIN).build();
+        String[] arguments =
+                new String[] {
+                    Integer.toString(keys.length),
+                    "key1",
+                    "key2",
+                    WEIGHTS_REDIS_API,
+                    "10.0",
+                    "20.0",
+                    AGGREGATE_REDIS_API,
+                    Aggregate.MIN.toString(),
+                    WITH_SCORES_REDIS_API
+                };
+        Map<String, Double> value = Map.of("elem1", 1.0, "elem2", 2.0);
+
+        CompletableFuture<Map<String, Double>> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Map<String, Double>>submitNewCommand(eq(ZUnion), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<String, Double>> response = service.zunionWithScores(keys, options);
+        Map<String, Double> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -417,6 +417,26 @@ public class TransactionTests {
         transaction.zunionWithScores(new String[] {"key1", "key2"});
         results.add(Pair.of(ZUnion, buildArgs("2", "key1", "key2", WITH_SCORES_REDIS_API)));
 
+        transaction.zunionWithScores(
+                new String[] {"key1", "key2"},
+                WeightAggregateOptions.builder()
+                        .weights(List.of(10.0, 20.0))
+                        .aggregate(Aggregate.MAX)
+                        .build());
+        results.add(
+                Pair.of(
+                        ZUnion,
+                        buildArgs(
+                                "2",
+                                "key1",
+                                "key2",
+                                WEIGHTS_REDIS_API,
+                                "10.0",
+                                "20.0",
+                                AGGREGATE_REDIS_API,
+                                Aggregate.MAX.toString(),
+                                WITH_SCORES_REDIS_API)));
+
         transaction.xadd("key", Map.of("field1", "foo1"));
         results.add(Pair.of(XAdd, buildArgs("key", "*", "field1", "foo1")));
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -35,6 +35,8 @@ import glide.api.models.commands.RangeOptions.ScoreBoundary;
 import glide.api.models.commands.ScriptOptions;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.StreamAddOptions;
+import glide.api.models.commands.WeightAggregateOptions;
+import glide.api.models.commands.WeightAggregateOptions.Aggregate;
 import glide.api.models.commands.ZaddOptions;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
@@ -1562,6 +1564,98 @@ public class SharedCommandTests {
                 assertThrows(
                         ExecutionException.class,
                         () -> client.zremrangebylex(key2, new LexBoundary("a"), new LexBoundary("c")).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void zunion(BaseClient client) {
+        String key1 = "{testKey}:1-" + UUID.randomUUID();
+        String key2 = "{testKey}:2-" + UUID.randomUUID();
+        String key3 = "{testKey}:3-" + UUID.randomUUID();
+        RangeByIndex query = new RangeByIndex(0, -1);
+        Map<String, Double> membersScores1 = Map.of("one", 1.0, "two", 2.0);
+        Map<String, Double> membersScores2 = Map.of("two", 3.5, "three", 3.0);
+
+        assertEquals(2, client.zadd(key1, membersScores1).get());
+        assertEquals(2, client.zadd(key2, membersScores2).get());
+
+        // Union results are aggregated by the sum of the scores of elements by default
+        assertArrayEquals(
+                new String[] {"one", "three", "two"}, client.zunion(new String[] {key1, key2}).get());
+        assertEquals(
+                Map.of("one", 1.0, "three", 3.0, "two", 5.5),
+                client.zunionWithScores(new String[] {key1, key2}).get());
+
+        // Union results are aggregated by the max score of elements
+        WeightAggregateOptions options =
+                WeightAggregateOptions.builder().aggregate(Aggregate.MAX).build();
+        assertArrayEquals(
+                new String[] {"one", "three", "two"},
+                client.zunion(new String[] {key1, key2}, options).get());
+        assertEquals(
+                Map.of("one", 1.0, "three", 3.0, "two", 3.5),
+                client.zunionWithScores(new String[] {key1, key2}, options).get());
+
+        // Union results are aggregated by the min score of elements
+        options = WeightAggregateOptions.builder().aggregate(Aggregate.MIN).build();
+        assertArrayEquals(
+                new String[] {"one", "two", "three"},
+                client.zunion(new String[] {key1, key2}, options).get());
+        assertEquals(
+                Map.of("one", 1.0, "two", 2.0, "three", 3.0),
+                client.zunionWithScores(new String[] {key1, key2}, options).get());
+
+        // Union results are aggregated by the sum of the scores of elements
+        options = WeightAggregateOptions.builder().aggregate(Aggregate.SUM).build();
+        assertArrayEquals(
+                new String[] {"one", "three", "two"},
+                client.zunion(new String[] {key1, key2}, options).get());
+        assertEquals(
+                Map.of("one", 1.0, "three", 3.0, "two", 5.5),
+                client.zunionWithScores(new String[] {key1, key2}, options).get());
+
+        // Scores are multiplied by 2.0 for key1 and key2 during aggregation.
+        options = WeightAggregateOptions.builder().weights(List.of(2.0, 2.0)).build();
+        assertArrayEquals(
+                new String[] {"one", "three", "two"},
+                client.zunion(new String[] {key1, key2}, options).get());
+        assertEquals(
+                Map.of("one", 2.0, "three", 6.0, "two", 11.0),
+                client.zunionWithScores(new String[] {key1, key2}, options).get());
+
+        // Union results are aggregated by the maximum score, with scores for key1 multiplied by 1.0 and
+        // for key2 by -2.0.
+        options =
+                WeightAggregateOptions.builder()
+                        .aggregate(Aggregate.MIN)
+                        .weights(List.of(1.0, -2.0))
+                        .build();
+        assertArrayEquals(
+                new String[] {"two", "three", "one"},
+                client.zunion(new String[] {key1, key2}, options).get());
+        assertEquals(
+                Map.of("two", -7.0, "three", -6.0, "one", 1.0),
+                client.zunionWithScores(new String[] {key1, key2}, options).get());
+
+        // Key exists, but it is not a set
+        assertEquals(OK, client.set(key3, "value").get());
+        ExecutionException executionException =
+                assertThrows(
+                        ExecutionException.class, () -> client.zunion(new String[] {key3, key2}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+
+        // Keys.length != Weights.length
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () ->
+                                client
+                                        .zunion(
+                                                new String[] {key1, key2},
+                                                WeightAggregateOptions.builder().weights(List.of(2.0)).build())
+                                        .get());
         assertTrue(executionException.getCause() instanceof RequestException);
     }
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -1625,7 +1625,7 @@ public class SharedCommandTests {
                 Map.of("one", 2.0, "three", 6.0, "two", 11.0),
                 client.zunionWithScores(new String[] {key1, key2}, options).get());
 
-        // Union results are aggregated by the maximum score, with scores for key1 multiplied by 1.0 and
+        // Union results are aggregated by the minimum score, with scores for key1 multiplied by 1.0 and
         // for key2 by -2.0.
         options =
                 WeightAggregateOptions.builder()

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -122,6 +122,8 @@ public class TransactionTestUtilities {
         baseTransaction.zadd(zSetKey2, Map.of("one", 1.0, "two", 2.0));
         baseTransaction.zdiff(new String[] {zSetKey2, key8});
         baseTransaction.zdiffWithScores(new String[] {zSetKey2, key8});
+        baseTransaction.zunion(new String[] {zSetKey2, key8});
+        baseTransaction.zunionWithScores(new String[] {zSetKey2, key8});
 
         baseTransaction.xadd(
                 key9, Map.of("field1", "value1"), StreamAddOptions.builder().id("0-1").build());
@@ -221,6 +223,10 @@ public class TransactionTestUtilities {
             2L, // zadd(zSetKey2, Map.of("one", 1.0, "two", 2.0))
             new String[] {"one", "two"}, // zdiff(new String[] {zSetKey2, key8})
             Map.of("one", 1.0, "two", 2.0), // zdiffWithScores(new String[] {zSetKey2, key8})
+            new String[] {"one", "two"}, // zdiffWithScores(new String[] {zSetKey2, key8})
+            Map.of(
+                    "one", 1.0, "two",
+                    2.0), // baseTransaction.zunionWithScores(new String[] {zSetKey2, key8})
             "0-1", // xadd(key9, Map.of("field1", "value1"),
             // StreamAddOptions.builder().id("0-1").build());
             "0-2", // xadd(key9, Map.of("field2", "value2"),

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -223,10 +223,8 @@ public class TransactionTestUtilities {
             2L, // zadd(zSetKey2, Map.of("one", 1.0, "two", 2.0))
             new String[] {"one", "two"}, // zdiff(new String[] {zSetKey2, key8})
             Map.of("one", 1.0, "two", 2.0), // zdiffWithScores(new String[] {zSetKey2, key8})
-            new String[] {"one", "two"}, // zdiffWithScores(new String[] {zSetKey2, key8})
-            Map.of(
-                    "one", 1.0, "two",
-                    2.0), // baseTransaction.zunionWithScores(new String[] {zSetKey2, key8})
+            new String[] {"one", "two"}, // zunion(new String[] {zSetKey2, key8})
+            Map.of("one", 1.0, "two", 2.0), // zunionWithScores(new String[] {zSetKey2, key8})
             "0-1", // xadd(key9, Map.of("field1", "value1"),
             // StreamAddOptions.builder().id("0-1").build());
             "0-2", // xadd(key9, Map.of("field2", "value2"),


### PR DESCRIPTION
https://redis.io/docs/latest/commands/zunionstore/
Data Conversion Required:
For the call to zunion when the "WITHSCORES" flag is passed. It returns a 2D array of [[String, Double]]. This return type needs to be converted to a MapOfStringDouble like ZDiff and ZRange.