### PR TITLE
Java: Add OBJECT ENCODING command

### DIFF
--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -152,6 +152,7 @@ enum RequestType {
     ZLexCount = 109;
     Append = 110;
     SInterStore = 114;
+    ObjectEncoding = 115;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -120,6 +120,7 @@ pub enum RequestType {
     ZLexCount = 109,
     Append = 110,
     SInterStore = 114,
+    ObjectEncoding = 115,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -243,6 +244,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::ZLexCount => RequestType::ZLexCount,
             ProtobufRequestType::Append => RequestType::Append,
             ProtobufRequestType::SInterStore => RequestType::SInterStore,
+            ProtobufRequestType::ObjectEncoding => RequestType::ObjectEncoding,
         }
     }
 }
@@ -362,6 +364,7 @@ impl RequestType {
             RequestType::ZLexCount => Some(cmd("ZLEXCOUNT")),
             RequestType::Append => Some(cmd("APPEND")),
             RequestType::SInterStore => Some(cmd("SINTERSTORE")),
+            RequestType::ObjectEncoding => Some(get_two_word_command("OBJECT", "ENCODING")),
         }
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -40,6 +40,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.LTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.Lindex;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
+import static redis_request.RedisRequestOuterClass.RequestType.ObjectEncoding;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpire;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpireAt;
 import static redis_request.RedisRequestOuterClass.RequestType.PTTL;
@@ -325,6 +326,12 @@ public abstract class BaseClient
     public CompletableFuture<String> mset(@NonNull Map<String, String> keyValueMap) {
         String[] args = convertMapToKeyValueStringArray(keyValueMap);
         return commandManager.submitNewCommand(MSet, args, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> objectEncoding(@NonNull String key) {
+        return commandManager.submitNewCommand(
+                ObjectEncoding, new String[] {key}, this::handleStringOrNullResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -384,7 +384,7 @@ public interface GenericBaseCommands {
      * String encoding = client.objectEncoding("my_hash").get();
      * assert encoding.equals("listpack");
      *
-     * String encoding = client.objectEncoding("non_existing_key").get();
+     * encoding = client.objectEncoding("non_existing_key").get();
      * assert encoding.equals(null);
      * }</pre>
      */

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -371,4 +371,22 @@ public interface GenericBaseCommands {
      * }</pre>
      */
     CompletableFuture<String> type(String key);
+
+    /**
+     * Returns the internal encoding for the Redis object stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/object-encoding/">redis.io</a> for details.
+     * @param key The <code>key</code> of the object to get the internal encoding of.
+     * @return If <code>key</code> exists, returns the internal encoding of the object stored at
+     *     <code>key</code> as a <code>String</code>. Otherwise, return <code>null</code>.
+     * @example
+     *     <pre>{@code
+     * String encoding = client.objectEncoding("key").get();
+     * assert encoding.equals("encoding");
+     *
+     * String encoding = client.objectEncoding("non_existing_key").get();
+     * assert encoding.equals(null);
+     * }</pre>
+     */
+    CompletableFuture<String> objectEncoding(String key);
 }

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -381,8 +381,8 @@ public interface GenericBaseCommands {
      *     <code>key</code> as a <code>String</code>. Otherwise, return <code>null</code>.
      * @example
      *     <pre>{@code
-     * String encoding = client.objectEncoding("key").get();
-     * assert encoding.equals("encoding");
+     * String encoding = client.objectEncoding("my_hash").get();
+     * assert encoding.equals("listpack");
      *
      * String encoding = client.objectEncoding("non_existing_key").get();
      * assert encoding.equals(null);

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -50,6 +50,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.LTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.Lindex;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
+import static redis_request.RedisRequestOuterClass.RequestType.ObjectEncoding;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpire;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpireAt;
 import static redis_request.RedisRequestOuterClass.RequestType.PTTL;
@@ -2052,6 +2053,21 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     public T pfmerge(@NonNull String destination, @NonNull String[] sourceKeys) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(sourceKeys, destination));
         protobufTransaction.addCommands(buildCommand(PfMerge, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns the internal encoding for the Redis object stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/object-encoding/">redis.io</a> for details.
+     * @param key The <code>key</code> of the object to get the internal encoding of.
+     * @return Command response - If <code>key</code> exists, returns the internal encoding of the
+     *     object stored at <code>key</code> as a <code>String</code>. Otherwise, return <code>null
+     *     </code>.
+     */
+    public T objectEncoding(@NonNull String key) {
+        ArgsArray commandArgs = buildArgs(key);
+        protobufTransaction.addCommands(buildCommand(ObjectEncoding, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -3006,6 +3006,8 @@ public class RedisClientTest {
         String encoding = "testEncoding";
         CompletableFuture<String> testResponse = new CompletableFuture<>();
         testResponse.complete(encoding);
+
+        // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(ObjectEncoding), eq(new String[] {key}), any()))
                 .thenReturn(testResponse);
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -70,6 +70,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.LTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.Lindex;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
+import static redis_request.RedisRequestOuterClass.RequestType.ObjectEncoding;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpire;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpireAt;
 import static redis_request.RedisRequestOuterClass.RequestType.PTTL;
@@ -2995,5 +2996,25 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(OK, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void objectEncoding_returns_success() {
+        // setup
+        String key = "testKey";
+        String encoding = "testEncoding";
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(encoding);
+        when(commandManager.<String>submitNewCommand(eq(ObjectEncoding), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.objectEncoding(key);
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(encoding, payload);
     }
 }

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -55,6 +55,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.LTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.Lindex;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
+import static redis_request.RedisRequestOuterClass.RequestType.ObjectEncoding;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpire;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpireAt;
 import static redis_request.RedisRequestOuterClass.RequestType.PTTL;
@@ -456,6 +457,9 @@ public class TransactionTests {
                 Pair.of(
                         PfMerge,
                         ArgsArray.newBuilder().addArgs("hll").addArgs("hll1").addArgs("hll2").build()));
+
+        transaction.objectEncoding("key");
+        results.add(Pair.of(ObjectEncoding, buildArgs("key")));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -2147,60 +2147,139 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
-    public void objectEncoding(BaseClient client) {
+    public void objectEncoding_returns_null(BaseClient client) {
         String nonExistingKey = UUID.randomUUID().toString();
-        String stringRawKey = UUID.randomUUID().toString();
-        String stringIntKey = UUID.randomUUID().toString();
-        String stringEmbstrKey = UUID.randomUUID().toString();
-        String listListpackKey = UUID.randomUUID().toString();
-        String setIntsetKey = UUID.randomUUID().toString();
-        String setHashtableKey = UUID.randomUUID().toString();
-        String setListpackKey = UUID.randomUUID().toString();
-        String hashHashtableKey = UUID.randomUUID().toString();
-        String hashListpackKey = UUID.randomUUID().toString();
-        String zsetSkiplistKey = UUID.randomUUID().toString();
-        String zsetListpackKey = UUID.randomUUID().toString();
-        String streamKey = UUID.randomUUID().toString();
+        assertNull(client.objectEncoding(nonExistingKey).get());
+    }
 
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_string_raw(BaseClient client) {
+        String stringRawKey = UUID.randomUUID().toString();
         assertEquals(
                 OK,
                 client
                         .set(stringRawKey, "a really loooooooooooooooooooooooooooooooooooooooong value")
                         .get());
+        assertEquals("raw", client.objectEncoding(stringRawKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_string_int(BaseClient client) {
+        String stringIntKey = UUID.randomUUID().toString();
         assertEquals(OK, client.set(stringIntKey, "2").get());
+        assertEquals("int", client.objectEncoding(stringIntKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_string_embstr(BaseClient client) {
+        String stringEmbstrKey = UUID.randomUUID().toString();
         assertEquals(OK, client.set(stringEmbstrKey, "value").get());
+        assertEquals("embstr", client.objectEncoding(stringEmbstrKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_list_listpack(BaseClient client) {
+        String listListpackKey = UUID.randomUUID().toString();
         assertEquals(1, client.lpush(listListpackKey, new String[] {"1"}).get());
+        // API documentation states that a ziplist should be returned for Redis versions <= 6.2, but
+        // actual behavior returns a quicklist.
+        assertEquals(
+                REDIS_VERSION.isLowerThan("7.0.0") ? "quicklist" : "listpack",
+                client.objectEncoding(listListpackKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_set_hashtable(BaseClient client) {
+        String setHashtableKey = UUID.randomUUID().toString();
         // The default value of set-max-intset-entries is 512
         for (Integer i = 0; i <= 512; i++) {
             assertEquals(1, client.sadd(setHashtableKey, new String[] {i.toString()}).get());
         }
+        assertEquals("hashtable", client.objectEncoding(setHashtableKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_set_intset(BaseClient client) {
+        String setIntsetKey = UUID.randomUUID().toString();
         assertEquals(1, client.sadd(setIntsetKey, new String[] {"1"}).get());
+        assertEquals("intset", client.objectEncoding(setIntsetKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_set_listpack(BaseClient client) {
+        String setListpackKey = UUID.randomUUID().toString();
         assertEquals(1, client.sadd(setListpackKey, new String[] {"foo"}).get());
+        assertEquals(
+                REDIS_VERSION.isLowerThan("7.2.0") ? "hashtable" : "listpack",
+                client.objectEncoding(setListpackKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_hash_hashtable(BaseClient client) {
+        String hashHashtableKey = UUID.randomUUID().toString();
         // The default value of hash-max-listpack-entries is 512
         for (Integer i = 0; i <= 512; i++) {
             assertEquals(1, client.hset(hashHashtableKey, Map.of(i.toString(), "2")).get());
         }
+        assertEquals("hashtable", client.objectEncoding(hashHashtableKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_hash_listpack(BaseClient client) {
+        String hashListpackKey = UUID.randomUUID().toString();
         assertEquals(1, client.hset(hashListpackKey, Map.of("1", "2")).get());
+        assertEquals(
+                REDIS_VERSION.isLowerThan("7.0.0") ? "ziplist" : "listpack",
+                client.objectEncoding(hashListpackKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_zset_skiplist(BaseClient client) {
+        String zsetSkiplistKey = UUID.randomUUID().toString();
         // The default value of zset-max-listpack-entries is 128
         for (Integer i = 0; i <= 128; i++) {
             assertEquals(1, client.zadd(zsetSkiplistKey, Map.of(i.toString(), 2d)).get());
         }
-        assertEquals(1, client.zadd(zsetListpackKey, Map.of("1", 2d)).get());
-        assertNotNull(client.xadd(streamKey, Map.of("field", "value")));
-
-        assertNull(client.objectEncoding(nonExistingKey).get());
-        assertEquals("raw", client.objectEncoding(stringRawKey).get());
-        assertEquals("int", client.objectEncoding(stringIntKey).get());
-        assertEquals("embstr", client.objectEncoding(stringEmbstrKey).get());
-        // API documentation states that a ziplist should be returned for Redis versions <= 6.2, but actual behavior returns a quicklist.
-        assertEquals(REDIS_VERSION.isLowerThan("7.0.0") ? "quicklist" : "listpack", client.objectEncoding(listListpackKey).get());
-        assertEquals("hashtable", client.objectEncoding(setHashtableKey).get());
-        assertEquals("intset", client.objectEncoding(setIntsetKey).get());
-        assertEquals(REDIS_VERSION.isLowerThan("7.2.0") ? "hashtable" : "listpack", client.objectEncoding(setListpackKey).get());
-        assertEquals("hashtable", client.objectEncoding(hashHashtableKey).get());
-        assertEquals(REDIS_VERSION.isLowerThan("7.0.0") ? "ziplist" : "listpack", client.objectEncoding(hashListpackKey).get());
         assertEquals("skiplist", client.objectEncoding(zsetSkiplistKey).get());
-        assertEquals(REDIS_VERSION.isLowerThan("7.0.0") ? "ziplist" : "listpack", client.objectEncoding(zsetListpackKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_zset_listpack(BaseClient client) {
+        String zsetListpackKey = UUID.randomUUID().toString();
+        assertEquals(1, client.zadd(zsetListpackKey, Map.of("1", 2d)).get());
+        assertEquals(
+                REDIS_VERSION.isLowerThan("7.0.0") ? "ziplist" : "listpack",
+                client.objectEncoding(zsetListpackKey).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void objectEncoding_returns_stream(BaseClient client) {
+        String streamKey = UUID.randomUUID().toString();
+        assertNotNull(client.xadd(streamKey, Map.of("field", "value")));
         assertEquals("stream", client.objectEncoding(streamKey).get());
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -2192,7 +2192,8 @@ public class SharedCommandTests {
         assertEquals("raw", client.objectEncoding(stringRawKey).get());
         assertEquals("int", client.objectEncoding(stringIntKey).get());
         assertEquals("embstr", client.objectEncoding(stringEmbstrKey).get());
-        assertEquals(REDIS_VERSION.isLowerThan("7.0.0") ? "ziplist" : "listpack", client.objectEncoding(listListpackKey).get());
+        // API documentation states that a ziplist should be returned for Redis versions <= 6.2, but actual behavior returns a quicklist.
+        assertEquals(REDIS_VERSION.isLowerThan("7.0.0") ? "quicklist" : "listpack", client.objectEncoding(listListpackKey).get());
         assertEquals("hashtable", client.objectEncoding(setHashtableKey).get());
         assertEquals("intset", client.objectEncoding(setIntsetKey).get());
         assertEquals(REDIS_VERSION.isLowerThan("7.2.0") ? "hashtable" : "listpack", client.objectEncoding(setListpackKey).get());

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -2189,29 +2189,17 @@ public class SharedCommandTests {
         assertNotNull(client.xadd(streamKey, Map.of("field", "value")));
 
         assertNull(client.objectEncoding(nonExistingKey).get());
-        assertTrue("raw".equalsIgnoreCase(client.objectEncoding(stringRawKey).get()));
-        assertTrue("int".equalsIgnoreCase(client.objectEncoding(stringIntKey).get()));
-        assertTrue("embstr".equalsIgnoreCase(client.objectEncoding(stringEmbstrKey).get()));
-        assertTrue(
-                REDIS_VERSION.isLowerThan("7.0.0")
-                        ? "ziplist".equalsIgnoreCase(client.objectEncoding(listListpackKey).get())
-                        : "listpack".equalsIgnoreCase(client.objectEncoding(listListpackKey).get()));
-        assertTrue("hashtable".equalsIgnoreCase(client.objectEncoding(setHashtableKey).get()));
-        assertTrue("intset".equalsIgnoreCase(client.objectEncoding(setIntsetKey).get()));
-        assertTrue(
-                REDIS_VERSION.isLowerThan("7.2.0")
-                        ? "hashtable".equalsIgnoreCase(client.objectEncoding(setListpackKey).get())
-                        : "listpack".equalsIgnoreCase(client.objectEncoding(setListpackKey).get()));
-        assertTrue("hashtable".equalsIgnoreCase(client.objectEncoding(hashHashtableKey).get()));
-        assertTrue(
-                REDIS_VERSION.isLowerThan("7.0.0")
-                        ? "ziplist".equalsIgnoreCase(client.objectEncoding(hashListpackKey).get())
-                        : "listpack".equalsIgnoreCase(client.objectEncoding(hashListpackKey).get()));
-        assertTrue("skiplist".equalsIgnoreCase(client.objectEncoding(zsetSkiplistKey).get()));
-        assertTrue(
-                REDIS_VERSION.isLowerThan("7.0.0")
-                        ? "ziplist".equalsIgnoreCase(client.objectEncoding(zsetListpackKey).get())
-                        : "listpack".equalsIgnoreCase(client.objectEncoding(zsetListpackKey).get()));
-        assertTrue("stream".equalsIgnoreCase(client.objectEncoding(streamKey).get()));
+        assertEquals("raw", client.objectEncoding(stringRawKey).get());
+        assertEquals("int", client.objectEncoding(stringIntKey).get());
+        assertEquals("embstr", client.objectEncoding(stringEmbstrKey).get());
+        assertEquals(REDIS_VERSION.isLowerThan("7.0.0") ? "ziplist" : "listpack", client.objectEncoding(listListpackKey).get());
+        assertEquals("hashtable", client.objectEncoding(setHashtableKey).get());
+        assertEquals("intset", client.objectEncoding(setIntsetKey).get());
+        assertEquals(REDIS_VERSION.isLowerThan("7.2.0") ? "hashtable" : "listpack", client.objectEncoding(setListpackKey).get());
+        assertEquals("hashtable", client.objectEncoding(hashHashtableKey).get());
+        assertEquals(REDIS_VERSION.isLowerThan("7.0.0") ? "ziplist" : "listpack", client.objectEncoding(hashListpackKey).get());
+        assertEquals("skiplist", client.objectEncoding(zsetSkiplistKey).get());
+        assertEquals(REDIS_VERSION.isLowerThan("7.0.0") ? "ziplist" : "listpack", client.objectEncoding(zsetListpackKey).get());
+        assertEquals("stream", client.objectEncoding(streamKey).get());
     }
 }

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -45,6 +45,7 @@ public class TransactionTestUtilities {
         baseTransaction.set(key1, value1);
         baseTransaction.get(key1);
         baseTransaction.type(key1);
+        baseTransaction.objectEncoding(key1);
 
         baseTransaction.set(key2, value2, SetOptions.builder().returnOldValue(true).build());
         baseTransaction.strlen(key2);
@@ -164,6 +165,7 @@ public class TransactionTestUtilities {
             OK,
             value1,
             "string", // type(key1)
+            "embstr", // objectEncoding(key1)
             null,
             (long) value1.length(), // strlen(key2)
             new String[] {value1, value2},


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
https://redis.io/commands/object-encoding/

The encodings that are no longer supported are not tested. The quicklist encoding is not tested because the default value for list-max-listpack-size is 8Kb and changing this value to something more practical to test requires updating the redis.conf.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.