### PR TITLE
Java: Publish JAR to local Maven repository

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -87,8 +87,9 @@ Other useful gradle developer commands:
 * `./gradlew :integTest:test` to run client examples
 * `./gradlew spotlessCheck` to check for codestyle issues
 * `./gradlew spotlessApply` to apply codestyle recommendations
-* `./gradlew :examples:run` to run client examples
+* `./gradlew :examples:run` to run client examples (Note: Make sure to run `./gradlew :client:publishToMavenLocal` first)
 * `./gradlew :benchmarks:run` to run performance benchmarks
+* `./gradlew :client:publishToMavenLocal` to publish the JAR to the local Maven repository
 
 ## Basic Examples
 

--- a/java/README.md
+++ b/java/README.md
@@ -87,9 +87,8 @@ Other useful gradle developer commands:
 * `./gradlew :integTest:test` to run client examples
 * `./gradlew spotlessCheck` to check for codestyle issues
 * `./gradlew spotlessApply` to apply codestyle recommendations
-* `./gradlew :examples:run` to run client examples (Note: Make sure to run `./gradlew :client:publishToMavenLocal` first)
+* `./gradlew :examples:run` to run client examples
 * `./gradlew :benchmarks:run` to run performance benchmarks
-* `./gradlew :client:publishToMavenLocal` to publish the JAR to the local Maven repository
 
 ## Basic Examples
 

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -172,7 +172,7 @@ sourceSets {
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            groupId = 'com.babushka'
+            groupId = 'software.amazon'
             artifactId = 'glide'
             version = "0.0.1"
             from components.java

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -152,7 +152,7 @@ tasks.register('copyNativeLib', Copy) {
 
 jar.dependsOn('copyNativeLib')
 copyNativeLib.dependsOn('buildRustRelease')
-compileTestJava.dependsOn('publishToMavenLocal')
+compileTestJava.dependsOn('copyNativeLib')
 
 test {
     exclude "glide/ffi/FfiTest.class"

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -152,6 +152,7 @@ tasks.register('copyNativeLib', Copy) {
 
 jar.dependsOn('copyNativeLib')
 copyNativeLib.dependsOn('buildRustRelease')
+compileTestJava.dependsOn('copyNativeLib')
 
 test {
     exclude "glide/ffi/FfiTest.class"
@@ -188,7 +189,6 @@ tasks.withType(Test) {
         events "started", "skipped", "passed", "failed"
         showStandardStreams true
     }
-    jvmArgs "-Djava.library.path=${projectDir}/../target/debug"
 }
 
 jar {

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -152,7 +152,7 @@ tasks.register('copyNativeLib', Copy) {
 
 jar.dependsOn('copyNativeLib')
 copyNativeLib.dependsOn('buildRustRelease')
-compileTestJava.dependsOn('copyNativeLib')
+compileTestJava.dependsOn('publishToMavenLocal')
 
 test {
     exclude "glide/ffi/FfiTest.class"

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -96,21 +96,10 @@ tasks.register('buildRustReleaseStrip', Exec) {
     environment CARGO_TERM_COLOR: 'always'
 }
 
-tasks.register('buildRust', Exec) {
-    commandLine 'cargo', 'build'
-    workingDir project.rootDir
-    environment CARGO_TERM_COLOR: 'always'
-}
-
 tasks.register('buildRustFfi', Exec) {
     commandLine 'cargo', 'build'
     workingDir project.rootDir
     environment CARGO_TERM_COLOR: 'always', CARGO_BUILD_RUSTFLAGS: '--cfg ffi_test'
-}
-
-tasks.register('buildWithRust') {
-    dependsOn 'buildRust'
-    finalizedBy 'build'
 }
 
 tasks.register('buildWithRustRelease') {
@@ -134,7 +123,7 @@ tasks.register('testFfi', Test) {
 }
 
 tasks.register('buildAll') {
-    dependsOn 'protobuf', 'buildRust', 'testFfi'
+    dependsOn 'protobuf', 'buildRustRelease', 'testFfi'
     finalizedBy 'build'
 }
 

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -2,6 +2,7 @@ import java.nio.file.Paths
 
 plugins {
     id 'java-library'
+    id 'maven-publish'
 }
 
 repositories {
@@ -84,23 +85,6 @@ tasks.register('cleanRust') {
     }
 }
 
-def rustBasePath = ".."
-
-tasks.create(name: "cargoOutputDir", description: "Get cargo metadata") {
-    new ByteArrayOutputStream().withStream { os ->
-        exec {
-            commandLine 'cargo', 'metadata', '--format-version', '1'
-            workingDir rustBasePath
-            standardOutput = os
-        }
-        def outputAsString = os.toString()
-        def json = new groovy.json.JsonSlurper().parseText(outputAsString)
-
-        logger.info("cargo target directory: ${json.target_directory}")
-        project.ext.cargo_target_directory = json.target_directory
-    }
-}
-
 tasks.register('buildRustRelease', Exec) {
     commandLine 'cargo', 'build', '--release'
     workingDir project.rootDir
@@ -150,17 +134,6 @@ tasks.register('testFfi', Test) {
     include "glide/ffi/FfiTest.class"
 }
 
-tasks.create(name: "cargoBuild", type: Exec, description: "Running Cargo build", dependsOn: "cargoOutputDir") {
-    workingDir rustBasePath
-    commandLine 'cargo', 'build', '--release'
-}
-
-tasks.create(name: "copyRustLib", type: Sync, dependsOn: "cargoBuild") {
-    from "${project.ext.cargo_target_directory}/release"
-    include "*.dylib","*.so"
-    into "rust-lib/"
-}
-
 tasks.register('buildAll') {
     dependsOn 'protobuf', 'buildRust', 'testFfi'
     finalizedBy 'build'
@@ -171,8 +144,42 @@ clean.dependsOn('cleanProtobuf', 'cleanRust')
 test.dependsOn('buildRust')
 testFfi.dependsOn('buildRust')
 
+tasks.register('copyNativeLib', Copy) {
+    from "${projectDir}/../target/release"
+    include "*.dylib", "*.so"
+    into sourceSets.main.output.resourcesDir
+}
+
+jar.dependsOn('copyNativeLib')
+copyNativeLib.dependsOn('buildRustRelease')
+
 test {
     exclude "glide/ffi/FfiTest.class"
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main/java'
+        }
+        resources {
+            srcDir 'src/main/resources'
+        }
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId = 'com.babushka'
+            artifactId = 'glide'
+            version = "0.0.1"
+            from components.java
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
 }
 
 tasks.withType(Test) {
@@ -184,33 +191,6 @@ tasks.withType(Test) {
     jvmArgs "-Djava.library.path=${projectDir}/../target/debug"
 }
 
-sourceSets {
-    main {
-        java {
-            srcDir 'src/main/java'
-        }
-        resources {
-            srcDir 'rust-lib'
-        }
-    }
-}
-
-tasks.named("processResources") {
-    mustRunAfter("copyRustLib")
-}
-
-tasks.withType(JavaCompile) {
-    compileTask -> compileTask.dependsOn "copyRustLib"
-}
-
 jar {
     archiveBaseName = "glide"
-
-    tasks.withType(Jar){
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    }
-
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
 }

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'java-library'
     id 'maven-publish'
 }
-
 repositories {
     mavenCentral()
 }
@@ -152,7 +151,7 @@ tasks.register('copyNativeLib', Copy) {
 
 jar.dependsOn('copyNativeLib')
 copyNativeLib.dependsOn('buildRustRelease')
-compileTestJava.dependsOn('copyNativeLib')
+compileTestJava.dependsOn('publishToMavenLocal')
 
 test {
     exclude "glide/ffi/FfiTest.class"

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -140,8 +140,6 @@ tasks.register('buildAll') {
 
 compileJava.dependsOn('protobuf')
 clean.dependsOn('cleanProtobuf', 'cleanRust')
-test.dependsOn('buildRust')
-testFfi.dependsOn('buildRust')
 
 tasks.register('copyNativeLib', Copy) {
     from "${projectDir}/../target/release"

--- a/java/client/src/main/java/glide/ffi/resolvers/NativeUtils.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/NativeUtils.java
@@ -59,12 +59,13 @@ public class NativeUtils {
     }
 
     public static void loadGlideLib() {
+        String glideLib = "/libglide_rs";
         try {
             String osName = System.getProperty("os.name").toLowerCase();
             if (osName.contains("mac")) {
-                NativeUtils.loadLibraryFromJar("/libglide_rs.dylib"); // for macOS, make sure this is .dylib rather than .so
+                NativeUtils.loadLibraryFromJar(glideLib + ".dylib");
             } else if (osName.contains("linux")) {
-                NativeUtils.loadLibraryFromJar("/libglide_rs.so"); // for macOS, make sure this is .dylib rather than .so
+                NativeUtils.loadLibraryFromJar(glideLib + ".so");
             } else {
                 throw new UnsupportedOperationException("OS not supported. Glide is only available on Mac OS and Linux systems.");
             }

--- a/java/client/src/main/java/glide/ffi/resolvers/NativeUtils.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/NativeUtils.java
@@ -1,26 +1,4 @@
-/*
- * Class NativeUtils is published under the The MIT License:
- *
- * Copyright (c) 2012 Adam Heinrich <adam@adamh.cz>
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.ffi.resolvers;
 
 import java.io.*;
@@ -31,32 +9,30 @@ import java.nio.file.ProviderNotFoundException;
 import java.nio.file.StandardCopyOption;
 
 /**
- * A simple library class which helps with loading dynamic libraries stored in the
- * JAR archive. These libraries usually contain implementation of some methods in
- * native code (using JNI - Java Native Interface).
+ * A simple library class which helps with loading dynamic libraries stored in the JAR archive.
+ * These libraries usually contain implementation of some methods in native code (using JNI - Java
+ * Native Interface).
  *
- * @see <a href="http://adamheinrich.com/blog/2012/how-to-load-native-jni-library-from-jar">http://adamheinrich.com/blog/2012/how-to-load-native-jni-library-from-jar</a>
- * @see <a href="https://github.com/adamheinrich/native-utils">https://github.com/adamheinrich/native-utils</a>
- *
+ * @see <a
+ *     href="http://adamheinrich.com/blog/2012/how-to-load-native-jni-library-from-jar">http://adamheinrich.com/blog/2012/how-to-load-native-jni-library-from-jar</a>
+ * @see <a
+ *     href="https://github.com/adamheinrich/native-utils">https://github.com/adamheinrich/native-utils</a>
  */
 public class NativeUtils {
 
     /**
-     * The minimum length a prefix for a file has to have according to {@link File#createTempFile(String, String)}}.
+     * The minimum length a prefix for a file has to have according to {@link
+     * File#createTempFile(String, String)}}.
      */
     private static final int MIN_PREFIX_LENGTH = 3;
+
     public static final String NATIVE_FOLDER_PATH_PREFIX = "nativeutils";
 
-    /**
-     * Temporary directory which will contain the DLLs.
-     */
+    /** Temporary directory which will contain the DLLs. */
     private static File temporaryDir;
 
-    /**
-     * Private constructor - this class will never be instanced
-     */
-    private NativeUtils() {
-    }
+    /** Private constructor - this class will never be instanced */
+    private NativeUtils() {}
 
     public static void loadGlideLib() {
         String glideLib = "/libglide_rs";
@@ -67,7 +43,8 @@ public class NativeUtils {
             } else if (osName.contains("linux")) {
                 NativeUtils.loadLibraryFromJar(glideLib + ".so");
             } else {
-                throw new UnsupportedOperationException("OS not supported. Glide is only available on Mac OS and Linux systems.");
+                throw new UnsupportedOperationException(
+                        "OS not supported. Glide is only available on Mac OS and Linux systems.");
             }
         } catch (java.io.IOException e) {
             e.printStackTrace();
@@ -77,15 +54,17 @@ public class NativeUtils {
     /**
      * Loads library from current JAR archive
      *
-     * The file from JAR is copied into system temporary directory and then loaded. The temporary file is deleted after
-     * exiting.
-     * Method uses String as filename because the pathname is "abstract", not system-dependent.
+     * <p>The file from JAR is copied into system temporary directory and then loaded. The temporary
+     * file is deleted after exiting. Method uses String as filename because the pathname is
+     * "abstract", not system-dependent.
      *
-     * @param path The path of file inside JAR as absolute path (beginning with '/'), e.g. /package/File.ext
+     * @param path The path of file inside JAR as absolute path (beginning with '/'), e.g.
+     *     /package/File.ext
      * @throws IOException If temporary file creation or read/write operation fails
      * @throws IllegalArgumentException If source file (param path) does not exist
-     * @throws IllegalArgumentException If the path is not absolute or if the filename is shorter than three characters
-     * (restriction of {@link File#createTempFile(java.lang.String, java.lang.String)}).
+     * @throws IllegalArgumentException If the path is not absolute or if the filename is shorter than
+     *     three characters (restriction of {@link File#createTempFile(java.lang.String,
+     *     java.lang.String)}).
      * @throws FileNotFoundException If the file could not be found inside the JAR.
      */
     public static void loadLibraryFromJar(String path) throws IOException {
@@ -136,12 +115,8 @@ public class NativeUtils {
 
     private static boolean isPosixCompliant() {
         try {
-            return FileSystems.getDefault()
-                .supportedFileAttributeViews()
-                .contains("posix");
-        } catch (FileSystemNotFoundException
-                 | ProviderNotFoundException
-                 | SecurityException e) {
+            return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+        } catch (FileSystemNotFoundException | ProviderNotFoundException | SecurityException e) {
             return false;
         }
     }

--- a/java/client/src/main/java/glide/ffi/resolvers/ScriptResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/ScriptResolver.java
@@ -1,8 +1,6 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.ffi.resolvers;
 
-import java.lang.annotation.Native;
-
 public class ScriptResolver {
 
     // TODO: consider lazy loading the glide_rs library

--- a/java/examples/build.gradle
+++ b/java/examples/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.5.0'
 }
 
+run.dependsOn ':client:publishToMavenLocal'
+
 application {
     // Define the main class for the application.
     mainClass = 'glide.examples.ExamplesApp'

--- a/java/examples/build.gradle
+++ b/java/examples/build.gradle
@@ -6,20 +6,18 @@ plugins {
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
-    implementation project(':client')
+    implementation 'com.babushka:glide:0.0.1'
 
     implementation 'redis.clients:jedis:4.4.3'
     implementation 'io.lettuce:lettuce-core:6.2.6.RELEASE'
     implementation 'commons-cli:commons-cli:1.5.0'
 }
 
-run.dependsOn ':client:buildRustRelease'
-
 application {
     // Define the main class for the application.
     mainClass = 'glide.examples.ExamplesApp'
-    applicationDefaultJvmArgs = ['-Djava.library.path=../target/release']
 }

--- a/java/examples/build.gradle
+++ b/java/examples/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.babushka:glide:0.0.1'
+    implementation 'software.amazon:glide:0.0.1'
 
     implementation 'redis.clients:jedis:4.4.3'
     implementation 'io.lettuce:lettuce-core:6.2.6.RELEASE'


### PR DESCRIPTION
This change publishes the Java glide client JAR to the local Maven repository. The built JAR file contains the Rust native lib code. This is not portable, so we will need to ensure that we build one JAR per supported platform.