### PR TITLE
Java: Add Netty epoll transport for ARM Linux

### DIFF
--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     // https://github.com/netty/netty/wiki/Native-transports
     // At the moment, Windows is not supported
     implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.100.Final', classifier: 'linux-x86_64'
+    implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.100.Final', classifier: 'linux-aarch_64'
     implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.100.Final', classifier: 'osx-x86_64'
     implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.100.Final', classifier: 'osx-aarch_64'
 


### PR DESCRIPTION
This change allows the Java client to properly run on ARM Linux.