### PR TITLE
Java: Add Logger

### DIFF
--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -19,7 +19,6 @@ public final class Logger {
         System.loadLibrary("glide_rs");
     }
 
-    // Enum ordinal is used, so order of variants must be kept the same
     @Getter
     public enum Level {
         DEFAULT(-1),
@@ -31,8 +30,19 @@ public final class Logger {
 
         private final int level;
 
-        private Level(int level) {
+        Level(int level) {
             this.level = level;
+        }
+
+        public static Level fromInt(int i) {
+            switch (i) {
+                case 0: return ERROR;
+                case 1: return WARN;
+                case 2: return INFO;
+                case 3: return DEBUG;
+                case 4: return TRACE;
+                default: return DEFAULT;
+            }
         }
     }
 
@@ -40,7 +50,7 @@ public final class Logger {
     private static Level loggerLevel;
 
     private static void initLogger(@NonNull Level level, String fileName) {
-        loggerLevel = Level.values()[initInternal(level.getLevel(), fileName)];
+        loggerLevel = Level.fromInt(initInternal(level.getLevel(), fileName));
     }
 
     private static void initLogger(String fileName) {

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -6,9 +6,11 @@ import lombok.NonNull;
 
 /**
  * A singleton class that allows logging which is consistent with logs from the internal rust core.
- * The logger can be set up in 2 ways - <br>
- * 1. By calling <code>Logger.init</code>, which configures the logger only if it wasn't previously configured.<br>
- * 2. By calling <code>Logger.setLoggerConfig</code>, which replaces the existing configuration, and means that new logs will not be
+ * The logger can be set up in 2 ways -
+ * <ol>
+ * <li>By calling <code>Logger.init</code>, which configures the logger only if it wasn't previously configured.</li>
+ * <li>By calling <code>Logger.setLoggerConfig</code>, which replaces the existing configuration, and means that new logs will not be</li>
+ * </ol>
  * saved with the logs that were sent before the call.<br><br>
  * If <code>setLoggerConfig</code> wasn't called, the first log attempt will initialize a new logger with default configuration decided
  * by the Rust core.

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -4,6 +4,9 @@ package glide.api.logging;
 import lombok.Getter;
 import lombok.NonNull;
 
+import static glide.ffi.resolvers.LoggerResolver.initInternal;
+import static glide.ffi.resolvers.LoggerResolver.logInternal;
+
 /**
  * A singleton class that allows logging which is consistent with logs from the internal rust core.
  * The logger can be set up in 2 ways -
@@ -175,8 +178,4 @@ public final class Logger {
     public static void setLoggerConfig() {
         setLoggerConfig(Level.DEFAULT, null);
     }
-
-    private static native int initInternal(int level, String fileName);
-
-    private static native void logInternal(int level, String logIdentifier, String message);
 }

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.logging;
 
 import lombok.Getter;
@@ -63,7 +64,8 @@ public class Logger {
         init(level, null);
     }
 
-    public static void log(@NonNull Level level, @NonNull String logIdentifier, @NonNull String message) {
+    public static void log(
+            @NonNull Level level, @NonNull String logIdentifier, @NonNull String message) {
         if (instance == null) {
             instance = new Logger(Level.DISABLED, null);
         }
@@ -80,5 +82,4 @@ public class Logger {
     private static native int initInternal(int level, String fileName);
 
     private static native void logInternal(int level, String logIdentifier, String message);
-
 }

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -21,7 +21,7 @@ import lombok.NonNull;
  * saved with the logs that were sent before the call.<br>
  * <br>
  * If <code>setLoggerConfig</code> wasn't called, the first log attempt will initialize a new logger
- * with default configuration decided by the Rust core.
+ * with default configuration decided by Glide core.
  */
 public final class Logger {
     @Getter
@@ -84,7 +84,7 @@ public final class Logger {
      *
      * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]
      *     </code>. If log level isn't provided, the logger will be configured with default
-     *     configuration decided by the Rust core.
+     *     configuration decided by Glide core.
      * @param fileName If provided, the target of the logs will be the file mentioned. Otherwise, logs
      *     will be printed to the console.
      */
@@ -97,7 +97,7 @@ public final class Logger {
     /**
      * Initialize a logger if it wasn't initialized before - this method is meant to be used when
      * there is no intention to replace an existing logger. The logger will filter all logs with a
-     * level lower than the default level decided by the Rust core. If given a <code>fileName</code>
+     * level lower than the default level decided by Glide core. If given a <code>fileName</code>
      * argument, will write the logs to files postfixed with <code>fileName</code>. If <code>fileName
      * </code> isn't provided, the logs will be written to the console.
      *
@@ -111,7 +111,7 @@ public final class Logger {
     /**
      * Initialize a logger if it wasn't initialized before - this method is meant to be used when
      * there is no intention to replace an existing logger. The logger will filter all logs with a
-     * level lower than the default level decided by the Rust core. The logs will be written to
+     * level lower than the default level decided by Glide core. The logs will be written to
      * stdout.
      */
     public static void init() {
@@ -125,7 +125,7 @@ public final class Logger {
      *
      * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]
      *     </code>. If log level isn't provided, the logger will be configured with default
-     *     configuration decided by the Rust core.
+     *     configuration decided by Glide core.
      */
     public static void init(@NonNull Level level) {
         init(level, null);
@@ -147,7 +147,7 @@ public final class Logger {
      *
      * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]
      *     </code>. If log level isn't provided, the logger will be configured with default
-     *     configuration decided by the Rust core.
+     *     configuration decided by Glide core.
      * @param fileName If provided, the target of the logs will be the file mentioned. Otherwise, logs
      *     will be printed to stdout.
      */
@@ -161,7 +161,7 @@ public final class Logger {
      *
      * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]
      *     </code>. If log level isn't provided, the logger will be configured with default
-     *     configuration decided by the Rust core.
+     *     configuration decided by Glide core.
      */
     public static void setLoggerConfig(@NonNull Level level) {
         setLoggerConfig(level, null);
@@ -181,7 +181,7 @@ public final class Logger {
 
     /**
      * Creates a new logger instance. The logger will filter all logs with a level lower than the
-     * default level decided by the Rust core. The logs will be written to stdout.
+     * default level decided by Glide core. The logs will be written to stdout.
      */
     public static void setLoggerConfig() {
         setLoggerConfig(Level.DEFAULT, null);

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -1,22 +1,27 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.logging;
 
-import lombok.Getter;
-import lombok.NonNull;
-
 import static glide.ffi.resolvers.LoggerResolver.initInternal;
 import static glide.ffi.resolvers.LoggerResolver.logInternal;
+
+import lombok.Getter;
+import lombok.NonNull;
 
 /**
  * A singleton class that allows logging which is consistent with logs from the internal rust core.
  * The logger can be set up in 2 ways -
+ *
  * <ol>
- * <li>By calling <code>Logger.init</code>, which configures the logger only if it wasn't previously configured.</li>
- * <li>By calling <code>Logger.setLoggerConfig</code>, which replaces the existing configuration, and means that new logs will not be</li>
+ *   <li>By calling <code>Logger.init</code>, which configures the logger only if it wasn't
+ *       previously configured.
+ *   <li>By calling <code>Logger.setLoggerConfig</code>, which replaces the existing configuration,
+ *       and means that new logs will not be
  * </ol>
- * saved with the logs that were sent before the call.<br><br>
- * If <code>setLoggerConfig</code> wasn't called, the first log attempt will initialize a new logger with default configuration decided
- * by the Rust core.
+ *
+ * saved with the logs that were sent before the call.<br>
+ * <br>
+ * If <code>setLoggerConfig</code> wasn't called, the first log attempt will initialize a new logger
+ * with default configuration decided by the Rust core.
  */
 public final class Logger {
     @Getter
@@ -36,18 +41,23 @@ public final class Logger {
 
         public static Level fromInt(int i) {
             switch (i) {
-                case 0: return ERROR;
-                case 1: return WARN;
-                case 2: return INFO;
-                case 3: return DEBUG;
-                case 4: return TRACE;
-                default: return DEFAULT;
+                case 0:
+                    return ERROR;
+                case 1:
+                    return WARN;
+                case 2:
+                    return INFO;
+                case 3:
+                    return DEBUG;
+                case 4:
+                    return TRACE;
+                default:
+                    return DEFAULT;
             }
         }
     }
 
-    @Getter
-    private static Level loggerLevel;
+    @Getter private static Level loggerLevel;
 
     private static void initLogger(@NonNull Level level, String fileName) {
         loggerLevel = Level.fromInt(initInternal(level.getLevel(), fileName));
@@ -66,16 +76,17 @@ public final class Logger {
     }
 
     /**
-     * Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
-     * replace an existing logger.
-     * The logger will filter all logs with a level lower than the given level.
-     * If given a <code>fileName</code> argument, will write the logs to files postfixed with <code>fileName</code>. If <code>fileName</code> isn't provided,
+     * Initialize a logger if it wasn't initialized before - this method is meant to be used when
+     * there is no intention to replace an existing logger. The logger will filter all logs with a
+     * level lower than the given level. If given a <code>fileName</code> argument, will write the
+     * logs to files postfixed with <code>fileName</code>. If <code>fileName</code> isn't provided,
      * the logs will be written to the console.
      *
-     * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]</code>.
-     * If log level isn't provided, the logger will be configured with default configuration decided by the Rust core.
-     * @param fileName If provided, the target of the logs will be the file mentioned.
-     * Otherwise, logs will be printed to the console.
+     * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]
+     *     </code>. If log level isn't provided, the logger will be configured with default
+     *     configuration decided by the Rust core.
+     * @param fileName If provided, the target of the logs will be the file mentioned. Otherwise, logs
+     *     will be printed to the console.
      */
     public static void init(@NonNull Level level, String fileName) {
         if (loggerLevel == null) {
@@ -84,37 +95,37 @@ public final class Logger {
     }
 
     /**
-     * Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
-     * replace an existing logger.
-     * The logger will filter all logs with a level lower than the default level decided by the Rust core.
-     * If given a <code>fileName</code> argument, will write the logs to files postfixed with <code>fileName</code>. If <code>fileName</code> isn't provided,
-     * the logs will be written to the console.
+     * Initialize a logger if it wasn't initialized before - this method is meant to be used when
+     * there is no intention to replace an existing logger. The logger will filter all logs with a
+     * level lower than the default level decided by the Rust core. If given a <code>fileName</code>
+     * argument, will write the logs to files postfixed with <code>fileName</code>. If <code>fileName
+     * </code> isn't provided, the logs will be written to the console.
      *
-     * @param fileName If provided, the target of the logs will be the file mentioned.
-     * Otherwise, logs will be printed to the console.
+     * @param fileName If provided, the target of the logs will be the file mentioned. Otherwise, logs
+     *     will be printed to the console.
      */
     public static void init(String fileName) {
         init(Level.DEFAULT, fileName);
     }
 
     /**
-     * Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
-     * replace an existing logger.
-     * The logger will filter all logs with a level lower than the default level decided by the Rust core.
-     * The logs will be written to stdout.
+     * Initialize a logger if it wasn't initialized before - this method is meant to be used when
+     * there is no intention to replace an existing logger. The logger will filter all logs with a
+     * level lower than the default level decided by the Rust core. The logs will be written to
+     * stdout.
      */
     public static void init() {
         init(Level.DEFAULT, null);
     }
 
     /**
-     * Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
-     * replace an existing logger.
-     * The logger will filter all logs with a level lower than the given level.
-     * The logs will be written to stdout.
+     * Initialize a logger if it wasn't initialized before - this method is meant to be used when
+     * there is no intention to replace an existing logger. The logger will filter all logs with a
+     * level lower than the given level. The logs will be written to stdout.
      *
-     * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]</code>.
-     * If log level isn't provided, the logger will be configured with default configuration decided by the Rust core.
+     * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]
+     *     </code>. If log level isn't provided, the logger will be configured with default
+     *     configuration decided by the Rust core.
      */
     public static void init(@NonNull Level level) {
         init(level, null);
@@ -134,41 +145,43 @@ public final class Logger {
     /**
      * Creates a new logger instance and configure it with the provided log level and file name.
      *
-     * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]</code>.
-     * If log level isn't provided, the logger will be configured with default configuration decided by the Rust core.
-     * @param fileName If provided, the target of the logs will be the file mentioned.
-     * Otherwise, logs will be printed to stdout.
+     * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]
+     *     </code>. If log level isn't provided, the logger will be configured with default
+     *     configuration decided by the Rust core.
+     * @param fileName If provided, the target of the logs will be the file mentioned. Otherwise, logs
+     *     will be printed to stdout.
      */
     public static void setLoggerConfig(@NonNull Level level, String fileName) {
         initLogger(level, fileName);
     }
 
     /**
-     * Creates a new logger instance and configure it with the provided log level.
-     * The logs will be written to stdout.
+     * Creates a new logger instance and configure it with the provided log level. The logs will be
+     * written to stdout.
      *
-     * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]</code>.
-     * If log level isn't provided, the logger will be configured with default configuration decided by the Rust core.
+     * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]
+     *     </code>. If log level isn't provided, the logger will be configured with default
+     *     configuration decided by the Rust core.
      */
     public static void setLoggerConfig(@NonNull Level level) {
         setLoggerConfig(level, null);
     }
 
     /**
-     * Creates a new logger instance and configure it with the provided file name and default log level.
-     * The logger will filter all logs with a level lower than the default level decided by the Rust core.
+     * Creates a new logger instance and configure it with the provided file name and default log
+     * level. The logger will filter all logs with a level lower than the default level decided by the
+     * Rust core.
      *
-     * @param fileName If provided, the target of the logs will be the file mentioned.
-     * Otherwise, logs will be printed to stdout.
+     * @param fileName If provided, the target of the logs will be the file mentioned. Otherwise, logs
+     *     will be printed to stdout.
      */
     public static void setLoggerConfig(String fileName) {
         setLoggerConfig(Level.DEFAULT, fileName);
     }
 
     /**
-     * Creates a new logger instance.
-     * The logger will filter all logs with a level lower than the default level decided by the Rust core.
-     * The logs will be written to stdout.
+     * Creates a new logger instance. The logger will filter all logs with a level lower than the
+     * default level decided by the Rust core. The logs will be written to stdout.
      */
     public static void setLoggerConfig() {
         setLoggerConfig(Level.DEFAULT, null);

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -146,8 +146,8 @@ public final class Logger {
     }
 
     /**
-     * Creates a new logger instance and configure it with the provided log level and to stdout.
-     * The logs will be written to the console.
+     * Creates a new logger instance and configure it with the provided log level.
+     * The logs will be written to stdout.
      *
      * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]</code>.
      * If log level isn't provided, the logger will be configured with default configuration decided by the Rust core.
@@ -157,7 +157,7 @@ public final class Logger {
     }
 
     /**
-     * Creates a new logger instance and configure it with the provided file name and default log level. 
+     * Creates a new logger instance and configure it with the provided file name and default log level.
      * The logger will filter all logs with a level lower than the default level decided by the Rust core.
      *
      * @param fileName If provided, the target of the logs will be the file mentioned.
@@ -168,7 +168,7 @@ public final class Logger {
     }
 
     /**
-     * Creates a new logger instance and configure it with the provided log level and file name.
+     * Creates a new logger instance.
      * The logger will filter all logs with a level lower than the default level decided by the Rust core.
      * The logs will be written to stdout.
      */

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -46,21 +46,21 @@ public class Logger {
         this(Level.DISABLED, null);
     }
 
-    public static void init(Level level, String fileName) {
+    public static void init(@NonNull Level level, String fileName) {
         if (instance == null) {
             instance = new Logger(level, fileName);
         }
     }
 
     public static void init(String fileName) {
-        init(null, fileName);
+        init(Level.DISABLED, fileName);
     }
 
     public static void init() {
-        init(null, null);
+        init(Level.DISABLED, null);
     }
 
-    public static void init(Level level) {
+    public static void init(@NonNull Level level) {
         init(level, null);
     }
 
@@ -75,7 +75,7 @@ public class Logger {
         logInternal(level.getLevel(), logIdentifier, message);
     }
 
-    public void setLoggerConfig(Level level, String fileName) {
+    public void setLoggerConfig(@NonNull Level level, String fileName) {
         instance = new Logger(level, fileName);
     }
 

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -103,7 +103,7 @@ public final class Logger {
      * Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
      * replace an existing logger.
      * The logger will filter all logs with a level lower than the default level decided by the Rust core.
-     * The logs will be written to the console.
+     * The logs will be written to stdout.
      */
     public static void init() {
         init(Level.DEFAULT, null);
@@ -113,7 +113,7 @@ public final class Logger {
      * Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
      * replace an existing logger.
      * The logger will filter all logs with a level lower than the given level.
-     * The logs will be written to the console.
+     * The logs will be written to stdout.
      *
      * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]</code>.
      * If log level isn't provided, the logger will be configured with default configuration decided by the Rust core.
@@ -139,14 +139,14 @@ public final class Logger {
      * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]</code>.
      * If log level isn't provided, the logger will be configured with default configuration decided by the Rust core.
      * @param fileName If provided, the target of the logs will be the file mentioned.
-     * Otherwise, logs will be printed to the console.
+     * Otherwise, logs will be printed to stdout.
      */
     public static void setLoggerConfig(@NonNull Level level, String fileName) {
         initLogger(level, fileName);
     }
 
     /**
-     * Creates a new logger instance and configure it with the provided log level and file name.
+     * Creates a new logger instance and configure it with the provided log level and to stdout.
      * The logs will be written to the console.
      *
      * @param level Set the logger level to one of <code>[DEFAULT, ERROR, WARN, INFO, DEBUG, TRACE]</code>.
@@ -157,11 +157,11 @@ public final class Logger {
     }
 
     /**
-     * Creates a new logger instance and configure it with the provided log level and file name.
+     * Creates a new logger instance and configure it with the provided file name and default log level. 
      * The logger will filter all logs with a level lower than the default level decided by the Rust core.
      *
      * @param fileName If provided, the target of the logs will be the file mentioned.
-     * Otherwise, logs will be printed to the console.
+     * Otherwise, logs will be printed to stdout.
      */
     public static void setLoggerConfig(String fileName) {
         setLoggerConfig(Level.DEFAULT, fileName);
@@ -170,7 +170,7 @@ public final class Logger {
     /**
      * Creates a new logger instance and configure it with the provided log level and file name.
      * The logger will filter all logs with a level lower than the default level decided by the Rust core.
-     * The logs will be written to the console.
+     * The logs will be written to stdout.
      */
     public static void setLoggerConfig() {
         setLoggerConfig(Level.DEFAULT, null);

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -111,8 +111,7 @@ public final class Logger {
     /**
      * Initialize a logger if it wasn't initialized before - this method is meant to be used when
      * there is no intention to replace an existing logger. The logger will filter all logs with a
-     * level lower than the default level decided by Glide core. The logs will be written to
-     * stdout.
+     * level lower than the default level decided by Glide core. The logs will be written to stdout.
      */
     public static void init() {
         init(Level.DEFAULT, null);

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -15,11 +15,9 @@ import lombok.NonNull;
  *   <li>By calling <code>Logger.init</code>, which configures the logger only if it wasn't
  *       previously configured.
  *   <li>By calling <code>Logger.setLoggerConfig</code>, which replaces the existing configuration,
- *       and means that new logs will not be
+ *       and means that new logs will not be saved with the logs that were sent before the call.
  * </ol>
  *
- * saved with the logs that were sent before the call.<br>
- * <br>
  * If <code>setLoggerConfig</code> wasn't called, the first log attempt will initialize a new logger
  * with default configuration decided by Glide core.
  */
@@ -169,7 +167,7 @@ public final class Logger {
     /**
      * Creates a new logger instance and configure it with the provided file name and default log
      * level. The logger will filter all logs with a level lower than the default level decided by the
-     * Rust core.
+     * Glide core.
      *
      * @param fileName If provided, the target of the logs will be the file mentioned. Otherwise, logs
      *     will be printed to stdout.

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -19,11 +19,6 @@ import static glide.ffi.resolvers.LoggerResolver.logInternal;
  * by the Rust core.
  */
 public final class Logger {
-    // TODO: consider lazy loading the glide_rs library
-    static {
-        System.loadLibrary("glide_rs");
-    }
-
     @Getter
     public enum Level {
         DEFAULT(-1),

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -1,0 +1,84 @@
+package glide.api.logging;
+
+import lombok.Getter;
+import lombok.NonNull;
+
+public class Logger {
+    // TODO: consider lazy loading the glide_rs library
+    static {
+        System.loadLibrary("glide_rs");
+    }
+
+    // Enum ordinal is used, so order of variants must be kept the same
+    @Getter
+    public enum Level {
+        DISABLED(-1),
+        ERROR(0),
+        WARN(1),
+        INFO(2),
+        DEBUG(3),
+        TRACE(4);
+
+        private final int level;
+
+        private Level(int level) {
+            this.level = level;
+        }
+    }
+
+    private static Logger instance;
+    private static Level loggerLevel;
+
+    private Logger(@NonNull Level level, String fileName) {
+        loggerLevel = Level.values()[initInternal(level.getLevel(), fileName)];
+    }
+
+    private Logger(String fileName) {
+        this(Level.DISABLED, fileName);
+    }
+
+    private Logger(@NonNull Level level) {
+        this(level, null);
+    }
+
+    private Logger() {
+        this(Level.DISABLED, null);
+    }
+
+    public static void init(Level level, String fileName) {
+        if (instance == null) {
+            instance = new Logger(level, fileName);
+        }
+    }
+
+    public static void init(String fileName) {
+        init(null, fileName);
+    }
+
+    public static void init() {
+        init(null, null);
+    }
+
+    public static void init(Level level) {
+        init(level, null);
+    }
+
+    public static void log(@NonNull Level level, @NonNull String logIdentifier, @NonNull String message) {
+        if (instance == null) {
+            instance = new Logger(Level.DISABLED, null);
+        }
+        if (!(level.getLevel() <= loggerLevel.getLevel())) {
+            return;
+        }
+        logInternal(level.getLevel(), logIdentifier, message);
+    }
+
+    public void setLoggerConfig(Level level, String fileName) {
+        instance = new Logger(level, fileName);
+    }
+
+    private static native int initInternal(int level, String fileName);
+
+    private static native void logInternal(int level, String logIdentifier, String message);
+
+}

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -18,6 +18,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import response.ResponseOuterClass.RequestError;
 import response.ResponseOuterClass.Response;
 
+import static glide.api.logging.Logger.Level.ERROR;
+
 /** Holder for resources required to dispatch responses and used by {@link ReadHandler}. */
 @RequiredArgsConstructor
 public class CallbackDispatcher {
@@ -109,7 +111,7 @@ public class CallbackDispatcher {
             future.completeAsync(() -> response);
         } else {
             // probably a response was received after shutdown or `registerRequest` call was missing
-            Logger.log(Logger.Level.ERROR, "callback dispatcher", "Received a response for not registered callback id " + callbackId + ", request error = " + response.getRequestError());
+            Logger.log(ERROR, "callback dispatcher", "Received a response for not registered callback id " + callbackId + ", request error = " + response.getRequestError());
             distributeClosingException("Client is in an erroneous state and should close");
         }
     }

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -1,6 +1,7 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
+import glide.api.logging.Logger;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.ConnectionException;
 import glide.api.models.exceptions.ExecAbortException;
@@ -107,11 +108,8 @@ public class CallbackDispatcher {
             }
             future.completeAsync(() -> response);
         } else {
-            // TODO: log an error thru logger.
             // probably a response was received after shutdown or `registerRequest` call was missing
-            System.err.printf(
-                    "Received a response for not registered callback id %d, request error = %s%n",
-                    callbackId, response.getRequestError());
+            Logger.log(Logger.Level.ERROR, "callback dispatcher", "Received a response for not registered callback id " + callbackId + ", request error = " + response.getRequestError() + "%n");
             distributeClosingException("Client is in an erroneous state and should close");
         }
     }

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -109,7 +109,7 @@ public class CallbackDispatcher {
             future.completeAsync(() -> response);
         } else {
             // probably a response was received after shutdown or `registerRequest` call was missing
-            Logger.log(Logger.Level.ERROR, "callback dispatcher", "Received a response for not registered callback id " + callbackId + ", request error = " + response.getRequestError() + "%n");
+            Logger.log(Logger.Level.ERROR, "callback dispatcher", "Received a response for not registered callback id " + callbackId + ", request error = " + response.getRequestError());
             distributeClosingException("Client is in an erroneous state and should close");
         }
     }

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -1,6 +1,8 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
+import static glide.api.logging.Logger.Level.ERROR;
+
 import glide.api.logging.Logger;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.ConnectionException;
@@ -17,8 +19,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import response.ResponseOuterClass.RequestError;
 import response.ResponseOuterClass.Response;
-
-import static glide.api.logging.Logger.Level.ERROR;
 
 /** Holder for resources required to dispatch responses and used by {@link ReadHandler}. */
 @RequiredArgsConstructor
@@ -111,7 +111,13 @@ public class CallbackDispatcher {
             future.completeAsync(() -> response);
         } else {
             // probably a response was received after shutdown or `registerRequest` call was missing
-            Logger.log(ERROR, "callback dispatcher", "Received a response for not registered callback id " + callbackId + ", request error = " + response.getRequestError());
+            Logger.log(
+                    ERROR,
+                    "callback dispatcher",
+                    "Received a response for not registered callback id "
+                            + callbackId
+                            + ", request error = "
+                            + response.getRequestError());
             distributeClosingException("Client is in an erroneous state and should close");
         }
     }

--- a/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
@@ -8,6 +8,8 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import response.ResponseOuterClass.Response;
 
+import static glide.api.logging.Logger.Level.ERROR;
+
 /** Handler for inbound traffic though UDS. Used by Netty. */
 @RequiredArgsConstructor
 public class ReadHandler extends ChannelInboundHandlerAdapter {
@@ -30,7 +32,7 @@ public class ReadHandler extends ChannelInboundHandlerAdapter {
     /** Handles uncaught exceptions from {@link #channelRead(ChannelHandlerContext, Object)}. */
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        Logger.log(Logger.Level.ERROR, "read handler", "=== exceptionCaught " + ctx + " " + cause);
+        Logger.log(ERROR, "read handler", "=== exceptionCaught " + ctx + " " + cause);
 
         callbackDispatcher.distributeClosingException(
                 "An unhandled error while reading from UDS channel: " + cause);

--- a/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
@@ -1,6 +1,7 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
+import glide.api.logging.Logger;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import lombok.NonNull;
@@ -29,8 +30,7 @@ public class ReadHandler extends ChannelInboundHandlerAdapter {
     /** Handles uncaught exceptions from {@link #channelRead(ChannelHandlerContext, Object)}. */
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        // TODO: log thru logger
-        System.out.printf("=== exceptionCaught %s %s %n", ctx, cause);
+        Logger.log(Logger.Level.ERROR, "read handler", "=== exceptionCaught " + ctx + " " + cause + " %n");
 
         callbackDispatcher.distributeClosingException(
                 "An unhandled error while reading from UDS channel: " + cause);

--- a/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
@@ -1,14 +1,14 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
+import static glide.api.logging.Logger.Level.ERROR;
+
 import glide.api.logging.Logger;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import response.ResponseOuterClass.Response;
-
-import static glide.api.logging.Logger.Level.ERROR;
 
 /** Handler for inbound traffic though UDS. Used by Netty. */
 @RequiredArgsConstructor

--- a/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
@@ -30,7 +30,7 @@ public class ReadHandler extends ChannelInboundHandlerAdapter {
     /** Handles uncaught exceptions from {@link #channelRead(ChannelHandlerContext, Object)}. */
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        Logger.log(Logger.Level.ERROR, "read handler", "=== exceptionCaught " + ctx + " " + cause + " %n");
+        Logger.log(Logger.Level.ERROR, "read handler", "=== exceptionCaught " + ctx + " " + cause);
 
         callbackDispatcher.distributeClosingException(
                 "An unhandled error while reading from UDS channel: " + cause);

--- a/java/client/src/main/java/glide/ffi/resolvers/LoggerResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/LoggerResolver.java
@@ -1,0 +1,13 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.ffi.resolvers;
+
+public class LoggerResolver {
+    // TODO: consider lazy loading the glide_rs library
+    static {
+        System.loadLibrary("glide_rs");
+    }
+
+    public static native int initInternal(int level, String fileName);
+
+    public static native void logInternal(int level, String logIdentifier, String message);
+}

--- a/java/client/src/main/java/module-info.java
+++ b/java/client/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module glide.api {
     exports glide.api;
     exports glide.api.commands;
+    exports glide.api.logging;
     exports glide.api.models;
     exports glide.api.models.commands;
     exports glide.api.models.commands.stream;

--- a/java/client/src/test/java/glide/connection/ConnectionWithGlideMockTests.java
+++ b/java/client/src/test/java/glide/connection/ConnectionWithGlideMockTests.java
@@ -7,10 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 
 import connection_request.ConnectionRequestOuterClass.ConnectionRequest;
 import connection_request.ConnectionRequestOuterClass.NodeAddress;
 import glide.api.RedisClient;
+import glide.api.logging.Logger;
 import glide.api.models.exceptions.ClosingException;
 import glide.connectors.handlers.CallbackDispatcher;
 import glide.connectors.handlers.ChannelHandler;
@@ -27,6 +29,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import redis_request.RedisRequestOuterClass.RedisRequest;
 import response.ResponseOuterClass.Response;
 

--- a/java/client/src/test/java/glide/connection/ConnectionWithGlideMockTests.java
+++ b/java/client/src/test/java/glide/connection/ConnectionWithGlideMockTests.java
@@ -7,12 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 
 import connection_request.ConnectionRequestOuterClass.ConnectionRequest;
 import connection_request.ConnectionRequestOuterClass.NodeAddress;
 import glide.api.RedisClient;
-import glide.api.logging.Logger;
 import glide.api.models.exceptions.ClosingException;
 import glide.connectors.handlers.CallbackDispatcher;
 import glide.connectors.handlers.ChannelHandler;
@@ -29,8 +27,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import redis_request.RedisRequestOuterClass.RedisRequest;
 import response.ResponseOuterClass.Response;
 

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -12,18 +12,18 @@ public class LoggerTests {
     @Test
     public void init_logger() {
         Logger.init(DEFAULT_TEST_LOG_LEVEL);
-        assertEquals(Logger.getLoggerLevel(), DEFAULT_TEST_LOG_LEVEL);
+        assertEquals(DEFAULT_TEST_LOG_LEVEL, Logger.getLoggerLevel());
         // The logger is already configured, so calling init again shouldn't modify the log level
         Logger.init(Logger.Level.ERROR);
-        assertEquals(Logger.getLoggerLevel(), DEFAULT_TEST_LOG_LEVEL);
+        assertEquals(DEFAULT_TEST_LOG_LEVEL, Logger.getLoggerLevel());
     }
 
     @Test
     public void set_logger_config() {
         Logger.setLoggerConfig(Logger.Level.INFO);
-        assertEquals(Logger.getLoggerLevel(), Logger.Level.INFO);
+        assertEquals(Logger.Level.INFO, Logger.getLoggerLevel());
         // Revert to the default test log level
         Logger.setLoggerConfig(DEFAULT_TEST_LOG_LEVEL);
-        assertEquals(Logger.getLoggerLevel(), DEFAULT_TEST_LOG_LEVEL);
+        assertEquals(DEFAULT_TEST_LOG_LEVEL, Logger.getLoggerLevel());
     }
 }

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -1,9 +1,16 @@
 package glide;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.api.logging.Logger;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Scanner;
 
 public class LoggerTests {
 
@@ -25,5 +32,42 @@ public class LoggerTests {
         // Revert to the default test log level
         Logger.setLoggerConfig(DEFAULT_TEST_LOG_LEVEL);
         assertEquals(DEFAULT_TEST_LOG_LEVEL, Logger.getLoggerLevel());
+    }
+
+    @SneakyThrows
+    @Test
+    public void log_to_file() {
+        String infoIdentifier = "Info";
+        String infoMessage = "foo";
+        String warnIdentifier = "Warn";
+        String warnMessage = "woof";
+        String errorIdentifier = "Error";
+        String errorMessage = "meow";
+        String debugIdentifier = "Debug";
+        String debugMessage = "chirp";
+        String traceIdentifier = "Trace";
+        String traceMessage = "squawk";
+
+        Logger.init(Logger.Level.INFO, "log.txt");
+        Logger.log(Logger.Level.INFO, infoIdentifier, infoMessage);
+        Logger.log(Logger.Level.WARN, warnIdentifier, warnMessage);
+        Logger.log(Logger.Level.ERROR, errorIdentifier, errorMessage);
+        Logger.log(Logger.Level.DEBUG, debugIdentifier, debugMessage);
+        Logger.log(Logger.Level.TRACE, traceIdentifier, traceMessage);
+
+        File logFolder = new File("glide-logs");
+        File[] logFiles = logFolder.listFiles((dir, name) -> name.startsWith("log.txt."));
+        assertNotNull(logFiles);
+        File logFile = logFiles[0];
+        logFile.deleteOnExit();
+        Scanner reader = new Scanner(logFile);
+        String infoLine = reader.nextLine();
+        assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
+        String warnLine = reader.nextLine();
+        assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
+        String errorLine = reader.nextLine();
+        assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
+        assertFalse(reader.hasNextLine());
+        reader.close();
     }
 }

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -1,0 +1,29 @@
+package glide;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import glide.api.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+public class LoggerTests {
+
+    private final Logger.Level DEFAULT_TEST_LOG_LEVEL = Logger.Level.WARN;
+
+    @Test
+    public void init_logger() {
+        Logger.init(DEFAULT_TEST_LOG_LEVEL);
+        assertEquals(Logger.getLoggerLevel(), DEFAULT_TEST_LOG_LEVEL);
+        // The logger is already configured, so calling init again shouldn't modify the log level
+        Logger.init(Logger.Level.ERROR);
+        assertEquals(Logger.getLoggerLevel(), DEFAULT_TEST_LOG_LEVEL);
+    }
+
+    @Test
+    public void set_logger_config() {
+        Logger.setLoggerConfig(Logger.Level.INFO);
+        assertEquals(Logger.getLoggerLevel(), Logger.Level.INFO);
+        // Revert to the default test log level
+        Logger.setLoggerConfig(DEFAULT_TEST_LOG_LEVEL);
+        assertEquals(Logger.getLoggerLevel(), DEFAULT_TEST_LOG_LEVEL);
+    }
+}

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -6,11 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.api.logging.Logger;
-import lombok.SneakyThrows;
-import org.junit.jupiter.api.Test;
-
 import java.io.File;
 import java.util.Scanner;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
 
 public class LoggerTests {
 

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -207,7 +207,7 @@ impl TryFrom<Level> for logger_core::Level {
 }
 
 #[no_mangle]
-pub extern "system" fn Java_glide_api_logging_Logger_logInternal<'local>(
+pub extern "system" fn Java_glide_ffi_resolvers_LoggerResolver_logInternal<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     level: jint,
@@ -230,7 +230,7 @@ pub extern "system" fn Java_glide_api_logging_Logger_logInternal<'local>(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_glide_api_logging_Logger_initInternal<'local>(
+pub extern "system" fn Java_glide_ffi_resolvers_LoggerResolver_initInternal<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     level: jint,

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -207,7 +207,7 @@ impl TryFrom<Level> for logger_core::Level {
 }
 
 #[no_mangle]
-pub extern "system" fn Java_glide_utils_Logger_logInternal<'local>(
+pub extern "system" fn Java_glide_api_logging_Logger_logInternal<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     level: jint,
@@ -230,7 +230,7 @@ pub extern "system" fn Java_glide_utils_Logger_logInternal<'local>(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_glide_utils_Logger_initInternal<'local>(
+pub extern "system" fn Java_glide_api_logging_Logger_initInternal<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
     level: jint,

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -240,7 +240,7 @@ pub extern "system" fn Java_glide_utils_Logger_initInternal<'local>(
     let file_name: Option<String> = match env.get_string(&file_name) {
         Ok(file_name) => Some(file_name.into()),
         Err(JniError::NullPtr(_)) => None,
-        _ => panic!(make_jstring_error("file_name")),
+        _ => panic!("{}", make_jstring_error("file_name")),
     };
     let logger_level = logger_core::init(
         level.map(|level| Level(level).try_into().unwrap()),

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -236,7 +236,7 @@ pub extern "system" fn Java_glide_api_logging_Logger_initInternal<'local>(
     level: jint,
     file_name: JString<'local>,
 ) -> jint {
-    let level = if level > 0 { Some(level) } else { None };
+    let level = if level >= 0 { Some(level) } else { None };
     let file_name: Option<String> = match env.get_string(&file_name) {
         Ok(file_name) => Some(file_name.into()),
         Err(JniError::NullPtr(_)) => None,

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -218,12 +218,12 @@ pub extern "system" fn Java_glide_utils_Logger_logInternal<'local>(
 
     let log_identifier: String = env
         .get_string(&log_identifier)
-        .expect(make_jstring_error("log_identifier").as_str())
+        .unwrap_or_else(|_| panic!("{}", make_jstring_error("log_identifier")))
         .into();
 
     let message: String = env
         .get_string(&message)
-        .expect(make_jstring_error("message").as_str())
+        .unwrap_or_else(|_| panic!("{}", make_jstring_error("message")))
         .into();
 
     logger_core::log(level.try_into().unwrap(), log_identifier, message);


### PR DESCRIPTION
The Logger implementation here is based on the Python client's implementation, with some relatively small Java/JNI specific changes.