### PR TITLE
Python: add BZMPOP command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Python: Added BLPOP and BRPOP commands ([#1369](https://github.com/aws/glide-for-redis/pull/1369))
 * Python: Added ZRANGESTORE command ([#1377](https://github.com/aws/glide-for-redis/pull/1377))
 * Python: Added ZDIFFSTORE command ([#1378](https://github.com/aws/glide-for-redis/pull/1378))
+* Python: Added BZMPOP command (TODO: add PR link)
 
 
 #### Fixes

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -21,6 +21,7 @@ pub(crate) enum ExpectedReturnType {
     Lolwut,
     ArrayOfArraysOfDoubleOrNull,
     ArrayOfKeyValuePairs,
+    ZMPopReturnType,
 }
 
 pub(crate) fn convert_to_expected_type(
@@ -178,6 +179,38 @@ pub(crate) fn convert_to_expected_type(
             _ => Err((
                 ErrorKind::TypeError,
                 "Response couldn't be converted to an array of doubles",
+                format!("(response was {:?})", value),
+            )
+                .into()),
+        },
+        // command returns nil or an array of 2 elements, where the second element is a map represented by a 2D array
+        // we convert that second element to a map as we do in `MapOfStringToDouble`
+        /*
+        127.0.0.1:6379> zmpop 1 z1 min count 10
+        1) "z1"
+        2) 1) 1) "2"
+              2) (double) 2
+           2) 1) "3"
+              2) (double) 3
+         */
+        ExpectedReturnType::ZMPopReturnType => match value {
+            Value::Nil => Ok(value),
+            Value::Array(array) if array.len() == 2 && matches!(array[1], Value::Array(_)) => {
+                let Value::Array(nested_array) = array[1].clone() else {
+                    unreachable!("Pattern match above ensures that it is Array")
+                };
+                // convert the nested array to a map
+                let map = convert_array_to_map(
+                    nested_array,
+                    Some(ExpectedReturnType::BulkString),
+                    Some(ExpectedReturnType::Double),
+                )?;
+
+                Ok(Value::Array(vec![array[0].clone(), map]))
+            }
+            _ => Err((
+                ErrorKind::TypeError,
+                "Response couldn't be converted",
                 format!("(response was {:?})", value),
             )
                 .into()),
@@ -403,6 +436,7 @@ pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType> {
         b"ZSCORE" | b"GEODIST" => Some(ExpectedReturnType::DoubleOrNull),
         b"ZMSCORE" => Some(ExpectedReturnType::ArrayOfDoubleOrNull),
         b"ZPOPMIN" | b"ZPOPMAX" => Some(ExpectedReturnType::MapOfStringToDouble),
+        b"BZMPOP" | b"ZMPOP" => Some(ExpectedReturnType::ZMPopReturnType),
         b"JSON.TOGGLE" => Some(ExpectedReturnType::JsonToggleReturnType),
         b"GEOPOS" => Some(ExpectedReturnType::ArrayOfArraysOfDoubleOrNull),
         b"HRANDFIELD" => cmd
@@ -591,6 +625,45 @@ mod tests {
             Some(ExpectedReturnType::ArrayOfKeyValuePairs)
         )
         .is_err());
+    }
+
+    #[test]
+    fn convert_zmpop_response() {
+        assert!(matches!(
+            expected_type_for_cmd(redis::cmd("BZMPOP").arg(1).arg(1).arg("key").arg("min")),
+            Some(ExpectedReturnType::ZMPopReturnType)
+        ));
+        assert!(matches!(
+            expected_type_for_cmd(redis::cmd("ZMPOP").arg(1).arg(1).arg("key").arg("min")),
+            Some(ExpectedReturnType::ZMPopReturnType)
+        ));
+
+        let redis_response = Value::Array(vec![
+            Value::SimpleString("key".into()),
+            Value::Array(vec![
+                Value::Array(vec![Value::SimpleString("elem1".into()), Value::Double(1.)]),
+                Value::Array(vec![Value::SimpleString("elem2".into()), Value::Double(2.)]),
+            ]),
+        ]);
+        let converted_response =
+            convert_to_expected_type(redis_response, Some(ExpectedReturnType::ZMPopReturnType))
+                .unwrap();
+        let expected_response = Value::Array(vec![
+            Value::SimpleString("key".into()),
+            Value::Map(vec![
+                (Value::BulkString("elem1".into()), Value::Double(1.)),
+                (Value::BulkString("elem2".into()), Value::Double(2.)),
+            ]),
+        ]);
+        assert_eq!(expected_response, converted_response);
+
+        let redis_response = Value::Nil;
+        let converted_response = convert_to_expected_type(
+            redis_response.clone(),
+            Some(ExpectedReturnType::ZMPopReturnType),
+        )
+        .unwrap();
+        assert_eq!(redis_response, converted_response);
     }
 
     #[test]

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -180,6 +180,7 @@ enum RequestType {
     FlushAll = 138;
     ZRandMember = 139;
     Bitcount = 140;
+    BZMPop = 141;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -150,6 +150,7 @@ pub enum RequestType {
     FlushAll = 138,
     ZRandMember = 139,
     Bitcount = 140,
+    BZMPop = 141,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -303,6 +304,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::FlushAll => RequestType::FlushAll,
             ProtobufRequestType::ZRandMember => RequestType::ZRandMember,
             ProtobufRequestType::Bitcount => RequestType::Bitcount,
+            ProtobufRequestType::BZMPop => RequestType::BZMPop,
         }
     }
 }
@@ -452,6 +454,7 @@ impl RequestType {
             RequestType::FlushAll => Some(cmd("FLUSHALL")),
             RequestType::ZRandMember => Some(cmd("ZRANDMEMBER")),
             RequestType::Bitcount => Some(cmd("BITCOUNT")),
+            RequestType::BZMPop => Some(cmd("BZMPOP")),
         }
     }
 }

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -24,7 +24,7 @@ from glide.async_commands.sorted_set import (
     RangeByLex,
     RangeByScore,
     ScoreBoundary,
-    ScoreModifier,
+    ScoreFilter,
 )
 from glide.async_commands.transaction import ClusterTransaction, Transaction
 from glide.config import (
@@ -99,7 +99,7 @@ __all__ = [
     "RangeByIndex",
     "RangeByLex",
     "RangeByScore",
-    "ScoreModifier",
+    "ScoreFilter",
     "StreamAddOptions",
     "StreamTrimOptions",
     "TrimByMaxLen",

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -24,6 +24,7 @@ from glide.async_commands.sorted_set import (
     RangeByLex,
     RangeByScore,
     ScoreBoundary,
+    ScoreModifier,
 )
 from glide.async_commands.transaction import ClusterTransaction, Transaction
 from glide.config import (
@@ -98,6 +99,7 @@ __all__ = [
     "RangeByIndex",
     "RangeByLex",
     "RangeByScore",
+    "ScoreModifier",
     "StreamAddOptions",
     "StreamTrimOptions",
     "TrimByMaxLen",

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -23,7 +23,7 @@ from glide.async_commands.sorted_set import (
     RangeByLex,
     RangeByScore,
     ScoreBoundary,
-    ScoreModifier,
+    ScoreFilter,
     _create_zrange_args,
     _create_zrangestore_args,
 )
@@ -2750,7 +2750,7 @@ class CoreCommands(Protocol):
     async def bzmpop(
         self,
         keys: List[str],
-        modifier: ScoreModifier,
+        modifier: ScoreFilter,
         timeout: float,
         count: Optional[int] = None,
     ) -> Optional[List[Union[str, Dict[str, float]]]]:
@@ -2770,7 +2770,7 @@ class CoreCommands(Protocol):
 
         Args:
             keys (List[str]): The keys of the sorted set.
-            modifier (ScoreModifier): The element pop criteria - either ScoreModifier.MIN or ScoreModifier.MAX to pop
+            modifier (ScoreFilter): The element pop criteria - either ScoreFilter.MIN or ScoreFilter.MAX to pop
                 members with the lowest/highest scores accordingly.
             timeout (float): The number of seconds to wait for a blocking operation to complete. A value of 0 will
                 block indefinitely.
@@ -2782,7 +2782,7 @@ class CoreCommands(Protocol):
                 popped and the timeout expired, returns None.
 
         Examples:
-            >>> await client.bzmpop(["zSet1", "zSet2"], ScoreModifier.MAX, 0.5, 2)
+            >>> await client.bzmpop(["zSet1", "zSet2"], ScoreFilter.MAX, 0.5, 2)
                 ['zSet1', {'two': 2.0, 'one': 1.0}]  # "two" with score 2.0 and "one" with score 1.0 were popped from "zSet1".
 
         Since: Redis version 7.0.0.

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -23,6 +23,7 @@ from glide.async_commands.sorted_set import (
     RangeByLex,
     RangeByScore,
     ScoreBoundary,
+    ScoreModifier,
     _create_zrange_args,
     _create_zrangestore_args,
 )
@@ -2744,6 +2745,55 @@ class CoreCommands(Protocol):
             await self._execute_command(
                 RequestType.ZDiffStore, [destination, str(len(keys))] + keys
             ),
+        )
+
+    async def bzmpop(
+        self,
+        keys: List[str],
+        modifier: ScoreModifier,
+        timeout: float,
+        count: Optional[int] = None,
+    ) -> Optional[List[Union[str, Dict[str, float]]]]:
+        """
+        Blocks the connection until it pops and returns a member-score pair from the first non-empty sorted set, with
+        the given keys being checked in the order they are provided. The optional `count` argument can be used to
+        specify the number of elements to pop, and is set to 1 by default. The number of popped elements is the minimum
+        from the sorted set's cardinality and `count`.
+
+        When in cluster mode, all keys must map to the same hash slot.
+
+        BZMPOP is the blocking variant of ZMPOP.
+
+        BZMPOP is a client blocking command, see https://github.com/aws/glide-for-redis/wiki/General-Concepts#blocking-commands for more details and best practices.
+
+        See https://valkey.io/commands/bzmpop for more details.
+
+        Args:
+            keys (List[str]): The keys of the sorted set.
+            modifier (ScoreModifier): The element pop criteria - either ScoreModifier.MIN or ScoreModifier.MAX to pop
+                members with the lowest/highest scores accordingly.
+            timeout (float): The number of seconds to wait for a blocking operation to complete. A value of 0 will
+                block indefinitely.
+            count (Optional[int]): The number of elements to pop.
+
+        Returns:
+            Optional[List[Union[str, Dict[str, float]]]]: A two-element list containing the key name of the set from
+                which elements were popped, and a member-score dict of the popped elements. If no members could be
+                popped and the timeout expired, returns None.
+
+        Examples:
+            >>> await client.bzmpop(["zSet1", "zSet2"], ScoreModifier.MAX, 0.5, 2)
+                ['zSet1', {'two': 2.0, 'one': 1.0}]  # "two" with score 2.0 and "one" with score 1.0 were popped from "zSet1".
+
+        Since: Redis version 7.0.0.
+        """
+        args = [str(timeout), str(len(keys))] + keys + [modifier.value]
+        if count is not None:
+            args = args + ["COUNT", str(count)]
+
+        return cast(
+            Optional[List[Union[str, Dict[str, float]]]],
+            await self._execute_command(RequestType.BZMPop, args),
         )
 
     async def invoke_script(

--- a/python/python/glide/async_commands/sorted_set.py
+++ b/python/python/glide/async_commands/sorted_set.py
@@ -23,6 +23,23 @@ class InfBound(Enum):
     """
 
 
+class ScoreModifier(Enum):
+    """
+    Defines which elements to pop from a sorted set.
+
+    ScoreModifier is a mandatory option for BZMPOP (https://google.github.io/proto-lens/installing-protoc.html).
+    """
+
+    MIN = "MIN"
+    """
+    Pop elements with the lowest scores.
+    """
+    MAX = "MAX"
+    """
+    Pop elements with the highest scores.
+    """
+
+
 class ScoreBoundary:
     """
     Represents a specific numeric score boundary in a sorted set.

--- a/python/python/glide/async_commands/sorted_set.py
+++ b/python/python/glide/async_commands/sorted_set.py
@@ -23,11 +23,11 @@ class InfBound(Enum):
     """
 
 
-class ScoreModifier(Enum):
+class ScoreFilter(Enum):
     """
     Defines which elements to pop from a sorted set.
 
-    ScoreModifier is a mandatory option for BZMPOP (https://valkey.io/commands/bzmpop).
+    ScoreFilter is a mandatory option for BZMPOP (https://valkey.io/commands/bzmpop).
     """
 
     MIN = "MIN"

--- a/python/python/glide/async_commands/sorted_set.py
+++ b/python/python/glide/async_commands/sorted_set.py
@@ -27,7 +27,7 @@ class ScoreModifier(Enum):
     """
     Defines which elements to pop from a sorted set.
 
-    ScoreModifier is a mandatory option for BZMPOP (https://google.github.io/proto-lens/installing-protoc.html).
+    ScoreModifier is a mandatory option for BZMPOP (https://valkey.io/commands/bzmpop).
     """
 
     MIN = "MIN"

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -22,6 +22,7 @@ from glide.async_commands.sorted_set import (
     RangeByLex,
     RangeByScore,
     ScoreBoundary,
+    ScoreModifier,
     _create_zrange_args,
     _create_zrangestore_args,
 )
@@ -1965,6 +1966,46 @@ class BaseTransaction:
         return self.append_command(
             RequestType.ZDiffStore, [destination, str(len(keys))] + keys
         )
+
+    def bzmpop(
+        self: TTransaction,
+        keys: List[str],
+        modifier: ScoreModifier,
+        timeout: float,
+        count: Optional[int] = None,
+    ) -> TTransaction:
+        """
+        Blocks the connection until it pops and returns a member-score pair from the first non-empty sorted set, with
+        the given keys being checked in the order they are provided. The optional `count` argument can be used to
+        specify the number of elements to pop, and is set to 1 by default. The number of popped elements is the minimum
+        from the sorted set's cardinality and `count`.
+
+        BZMPOP is the blocking variant of ZMPOP.
+
+        BZMPOP is a client blocking command, see https://github.com/aws/glide-for-redis/wiki/General-Concepts#blocking-commands for more details and best practices.
+
+        See https://valkey.io/commands/bzmpop for more details.
+
+        Args:
+            keys (List[str]): The keys of the sorted set.
+            modifier (ScoreModifier): The element pop criteria - either ScoreModifier.MIN or ScoreModifier.MAX to pop
+                members with the lowest/highest scores accordingly.
+            timeout (float): The number of seconds to wait for a blocking operation to complete. A value of 0 will
+                block indefinitely.
+            count (Optional[int]): The number of elements to pop.
+
+        Command response:
+            Optional[List[Union[str, Dict[str, float]]]]: A two-element list containing the key name of the set from
+                which elements were popped, and a member-score dict. If no members could be popped and the timeout
+                expired, returns None.
+
+        Since: Redis version 7.0.0.
+        """
+        args = [str(timeout), str(len(keys))] + keys + [modifier.value]
+        if count is not None:
+            args = args + ["COUNT", str(count)]
+
+        return self.append_command(RequestType.BZMPop, args)
 
     def dbsize(self: TTransaction) -> TTransaction:
         """

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -22,7 +22,7 @@ from glide.async_commands.sorted_set import (
     RangeByLex,
     RangeByScore,
     ScoreBoundary,
-    ScoreModifier,
+    ScoreFilter,
     _create_zrange_args,
     _create_zrangestore_args,
 )
@@ -1970,7 +1970,7 @@ class BaseTransaction:
     def bzmpop(
         self: TTransaction,
         keys: List[str],
-        modifier: ScoreModifier,
+        modifier: ScoreFilter,
         timeout: float,
         count: Optional[int] = None,
     ) -> TTransaction:
@@ -1988,7 +1988,7 @@ class BaseTransaction:
 
         Args:
             keys (List[str]): The keys of the sorted set.
-            modifier (ScoreModifier): The element pop criteria - either ScoreModifier.MIN or ScoreModifier.MAX to pop
+            modifier (ScoreFilter): The element pop criteria - either ScoreFilter.MIN or ScoreFilter.MAX to pop
                 members with the lowest/highest scores accordingly.
             timeout (float): The number of seconds to wait for a blocking operation to complete. A value of 0 will
                 block indefinitely.

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -2405,8 +2405,7 @@ class TestCommands:
 
         # ensure that command doesn't time out even if timeout > request timeout (250ms by default)
         assert (
-            await redis_client.bzmpop([non_existing_key], ScoreFilter.MIN, 0.5)
-            is None
+            await redis_client.bzmpop([non_existing_key], ScoreFilter.MIN, 0.5) is None
         )
         assert (
             await redis_client.bzmpop([non_existing_key], ScoreFilter.MIN, 0.55, 1)

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -33,6 +33,7 @@ from glide.async_commands.sorted_set import (
     RangeByLex,
     RangeByScore,
     ScoreBoundary,
+    ScoreModifier,
 )
 from glide.config import ProtocolVersion, RedisCredentials
 from glide.constants import OK, TResult
@@ -883,9 +884,8 @@ class TestCommands:
         value_list = [value1, value2]
 
         assert await redis_client.lpush(key1, value_list) == 2
-        # ensure that command doesn't time out even if timeout > request timeout (250ms by default)
         assert await redis_client.blpop([key1, key2], 0.5) == [key1, value2]
-
+        # ensure that command doesn't time out even if timeout > request timeout (250ms by default)
         assert await redis_client.blpop(["non_existent_key"], 0.5) is None
 
         # key exists, but not a list
@@ -2376,6 +2376,74 @@ class TestCommands:
         if isinstance(redis_client, RedisClusterClient):
             with pytest.raises(RequestError) as e:
                 await redis_client.zdiffstore("abc", ["zxy", "lkn"])
+            assert "CrossSlot" in str(e)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_bzmpop(self, redis_client: TRedisClient):
+        min_version = "7.0.0"
+        if await check_if_server_version_lt(redis_client, min_version):
+            # TODO: change it to pytest fixture after we'll implement a sync client
+            return pytest.mark.skip(reason=f"Redis version required >= {min_version}")
+
+        key1 = f"{{test}}-1-f{get_random_string(10)}"
+        key2 = f"{{test}}-2-f{get_random_string(10)}"
+        non_existing_key = f"{{test}}-non_existing_key"
+        string_key = f"{{test}}-3-f{get_random_string(10)}"
+
+        assert await redis_client.zadd(key1, {"a1": 1, "b1": 2}) == 2
+        assert await redis_client.zadd(key2, {"a2": 0.1, "b2": 0.2}) == 2
+
+        assert await redis_client.bzmpop([key1, key2], ScoreModifier.MAX, 0.1) == [
+            key1,
+            {"b1": 2},
+        ]
+        assert await redis_client.bzmpop([key2, key1], ScoreModifier.MAX, 0.1, 10) == [
+            key2,
+            {"b2": 0.2, "a2": 0.1},
+        ]
+
+        # ensure that command doesn't time out even if timeout > request timeout (250ms by default)
+        assert (
+            await redis_client.bzmpop([non_existing_key], ScoreModifier.MIN, 0.5)
+            is None
+        )
+        assert (
+            await redis_client.bzmpop([non_existing_key], ScoreModifier.MIN, 0.55, 1)
+            is None
+        )
+
+        # key exists, but it is not a sorted set
+        assert await redis_client.set(string_key, "value") == OK
+        with pytest.raises(RequestError):
+            await redis_client.bzmpop([string_key], ScoreModifier.MAX, 0.1)
+        with pytest.raises(RequestError):
+            await redis_client.bzmpop([string_key], ScoreModifier.MAX, 0.1, 1)
+
+        # incorrect argument: count should be greater than 0
+        with pytest.raises(RequestError):
+            assert await redis_client.bzmpop([key1], ScoreModifier.MAX, 0.1, 0)
+
+        # check that order of entries in the response is preserved
+        entries = {}
+        for i in range(0, 10):
+            entries.update({f"a{i}": float(i)})
+
+        assert await redis_client.zadd(key2, entries) == 10
+        assert await redis_client.bzmpop([key2], ScoreModifier.MIN, 0.1, 10) == [key2, entries]
+
+        async def endless_bzmpop_call():
+            await redis_client.bzmpop(["non_existent_key"], 0)
+
+        # bzmpop is called against a non-existing key with no timeout, but we wrap the call in an asyncio timeout to
+        # avoid having the test block forever
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(endless_bzmpop_call(), timeout=0.5)
+
+        # same-slot requirement
+        if isinstance(redis_client, RedisClusterClient):
+            with pytest.raises(RequestError) as e:
+                await redis_client.bzmpop(["abc", "zxy", "lkn"], ScoreModifier.MAX, 0.1)
             assert "CrossSlot" in str(e)
 
     @pytest.mark.parametrize("cluster_mode", [True, False])

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -2430,10 +2430,13 @@ class TestCommands:
             entries.update({f"a{i}": float(i)})
 
         assert await redis_client.zadd(key2, entries) == 10
-        assert await redis_client.bzmpop([key2], ScoreModifier.MIN, 0.1, 10) == [key2, entries]
+        assert await redis_client.bzmpop([key2], ScoreModifier.MIN, 0.1, 10) == [
+            key2,
+            entries,
+        ]
 
         async def endless_bzmpop_call():
-            await redis_client.bzmpop(["non_existent_key"], 0)
+            await redis_client.bzmpop(["non_existent_key"], ScoreModifier.MAX, 0)
 
         # bzmpop is called against a non-existing key with no timeout, but we wrap the call in an asyncio timeout to
         # avoid having the test block forever

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -2420,6 +2420,10 @@ class TestCommands:
         with pytest.raises(RequestError):
             await redis_client.bzmpop([string_key], ScoreFilter.MAX, 0.1, 1)
 
+        # incorrect argument: key list should not be empty
+        with pytest.raises(RequestError):
+            assert await redis_client.bzmpop([], ScoreFilter.MAX, 0.1, 1)
+
         # incorrect argument: count should be greater than 0
         with pytest.raises(RequestError):
             assert await redis_client.bzmpop([key1], ScoreFilter.MAX, 0.1, 0)

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -16,6 +16,7 @@ from glide.async_commands.sorted_set import (
     LexBoundary,
     RangeByIndex,
     ScoreBoundary,
+    ScoreModifier,
 )
 from glide.async_commands.transaction import (
     BaseTransaction,
@@ -270,6 +271,19 @@ async def transaction_test(
     args.append("0-2")
     transaction.xtrim(key11, TrimByMinId(threshold="0-2", exact=True))
     args.append(1)
+
+    min_version = "7.0.0"
+    if not await check_if_server_version_lt(redis_client, min_version):
+        # TODO: change it to pytest fixture after we'll implement a sync client
+        zset_key = "{{{}}}:{}".format(keyslot, get_random_string(3))
+
+        transaction.zadd(zset_key, {"a": 1, "b": 2, "c": 3, "d": 4})
+        args.append(4)
+        transaction.bzmpop([zset_key], ScoreModifier.MAX, 0.1)
+        args.append([zset_key, {"d": 4.0}])
+        transaction.bzmpop([zset_key], ScoreModifier.MIN, 0.1, 2)
+        args.append([zset_key, {"a": 1.0, "b": 2.0}])
+
     return args
 
 

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -16,7 +16,7 @@ from glide.async_commands.sorted_set import (
     LexBoundary,
     RangeByIndex,
     ScoreBoundary,
-    ScoreModifier,
+    ScoreFilter,
 )
 from glide.async_commands.transaction import (
     BaseTransaction,
@@ -279,9 +279,9 @@ async def transaction_test(
 
         transaction.zadd(zset_key, {"a": 1, "b": 2, "c": 3, "d": 4})
         args.append(4)
-        transaction.bzmpop([zset_key], ScoreModifier.MAX, 0.1)
+        transaction.bzmpop([zset_key], ScoreFilter.MAX, 0.1)
         args.append([zset_key, {"d": 4.0}])
-        transaction.bzmpop([zset_key], ScoreModifier.MIN, 0.1, 2)
+        transaction.bzmpop([zset_key], ScoreFilter.MIN, 0.1, 2)
         args.append([zset_key, {"a": 1.0, "b": 2.0}])
 
     return args


### PR DESCRIPTION
https://redis.io/docs/latest/commands/bzmpop/

Note: 
- contains the same .rs and .proto changes as https://github.com/aws/glide-for-redis/pull/1390
- depends on https://github.com/aws/glide-for-redis/pull/1319 (will need to refactor tests to use compare_maps once 1319 is merged)