### PR TITLE
Update transaction IT.

### DIFF
--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -85,8 +85,9 @@ public class TestUtilities {
      * Deep traverse and compare two objects, including comparing content of all nested collections
      * recursively.
      *
-     * @apiNote Maps comparison ignores their order, regardless of `orderMatters` argument. Map
-     *     entries could be reordered, but values stored in them compared according to this parameter.
+     * @apiNote Maps and Set comparison ignores their order, regardless of `orderMatters` argument.
+     *     Their entries could be reordered, but values stored in them compared according to this
+     *     parameter.
      */
     public static void assertDeepEquals(Object expected, Object actual, boolean orderMatters) {
         if (expected == null || actual == null) {
@@ -112,16 +113,8 @@ public class TestUtilities {
         } else if (expected instanceof Set) {
             var expectedSet = (Set<?>) expected;
             var actualSet = (Set<?>) actual;
-            var expectedArray = expectedSet.toArray();
-            var actualArray = actualSet.toArray();
-            assertEquals(expectedArray.length, actualArray.length);
-            if (orderMatters) {
-                for (int i = 0; i < expectedArray.length; i++) {
-                    assertDeepEquals(expectedArray[i], actualArray[i], orderMatters);
-                }
-            } else {
-                assertTrue(expectedSet.containsAll(actualSet) && actualSet.containsAll(expectedSet));
-            }
+            assertEquals(expectedSet.size(), actualSet.size());
+            assertTrue(expectedSet.containsAll(actualSet) && actualSet.containsAll(expectedSet));
         } else if (expected instanceof Map) {
             var expectedMap = (Map<?, ?>) expected;
             var actualMap = (Map<?, ?>) actual;

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -3,6 +3,8 @@ package glide;
 
 import static glide.TestConfiguration.CLUSTER_PORTS;
 import static glide.TestConfiguration.STANDALONE_PORTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import glide.api.models.ClusterValue;
@@ -11,7 +13,9 @@ import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
 import java.security.SecureRandom;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 
@@ -75,5 +79,59 @@ public class TestUtilities {
             commonClusterClientConfig() {
         return RedisClusterClientConfiguration.builder()
                 .address(NodeAddress.builder().port(CLUSTER_PORTS[0]).build());
+    }
+
+    /**
+     * Deep traverse and compare two objects, including comparing content of all nested collections
+     * recursively.
+     *
+     * @apiNote Maps comparison ignores their order, regardless of `orderMatters` argument. Map
+     *     entries could be reordered, but values stored in them compared according to this parameter.
+     */
+    public static void assertDeepEquals(Object expected, Object actual, boolean orderMatters) {
+        if (expected == null || actual == null) {
+            assertEquals(expected, actual);
+        } else if (expected.getClass().isArray()) {
+            var expectedArray = (Object[]) expected;
+            var actualArray = (Object[]) actual;
+            assertEquals(expectedArray.length, actualArray.length);
+            for (int i = 0; i < expectedArray.length; i++) {
+                assertDeepEquals(expectedArray[i], actualArray[i], orderMatters);
+            }
+        } else if (expected instanceof List) {
+            var expectedList = (List<?>) expected;
+            var actualList = (List<?>) actual;
+            assertEquals(expectedList.size(), actualList.size());
+            if (orderMatters) {
+                for (int i = 0; i < expectedList.size(); i++) {
+                    assertDeepEquals(expectedList.get(i), actualList.get(i), orderMatters);
+                }
+            } else {
+                assertTrue(expectedList.containsAll(actualList) && actualList.containsAll(expectedList));
+            }
+        } else if (expected instanceof Set) {
+            var expectedSet = (Set<?>) expected;
+            var actualSet = (Set<?>) actual;
+            var expectedArray = expectedSet.toArray();
+            var actualArray = actualSet.toArray();
+            assertEquals(expectedArray.length, actualArray.length);
+            if (orderMatters) {
+                for (int i = 0; i < expectedArray.length; i++) {
+                    assertDeepEquals(expectedArray[i], actualArray[i], orderMatters);
+                }
+            } else {
+                assertTrue(expectedSet.containsAll(actualSet) && actualSet.containsAll(expectedSet));
+            }
+        } else if (expected instanceof Map) {
+            var expectedMap = (Map<?, ?>) expected;
+            var actualMap = (Map<?, ?>) actual;
+            assertEquals(expectedMap.size(), actualMap.size());
+            assertDeepEquals(expectedMap.keySet(), actualMap.keySet(), false);
+            for (var key : expectedMap.keySet()) {
+                assertDeepEquals(expectedMap.get(key), actualMap.get(key), orderMatters);
+            }
+        } else {
+            assertEquals(expected, actual);
+        }
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -123,6 +123,8 @@ public class TestUtilities {
             for (var key : expectedMap.keySet()) {
                 assertDeepEquals(expectedMap.get(key), actualMap.get(key), orderMatters);
             }
+        } else if (expected instanceof Double || actual instanceof Double) {
+            assertEquals((Double) expected, (Double) actual, 1e-6);
         } else {
             assertEquals(expected, actual);
         }

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -2,6 +2,7 @@
 package glide.cluster;
 
 import static glide.TestConfiguration.REDIS_VERSION;
+import static glide.TestUtilities.assertDeepEquals;
 import static glide.api.BaseClient.OK;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleSingleNodeRoute.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -91,7 +92,7 @@ public class ClusterTransactionTests {
         Object[] expectedResult = builder.apply(transaction);
 
         Object[] results = clusterClient.exec(transaction).get();
-        assertArrayEquals(expectedResult, results);
+        assertDeepEquals(expectedResult, results, true);
     }
 
     @SneakyThrows
@@ -104,7 +105,7 @@ public class ClusterTransactionTests {
 
         SingleNodeRoute route = new SlotIdRoute(1, SlotType.PRIMARY);
         Object[] results = clusterClient.exec(transaction, route).get();
-        assertArrayEquals(expectedResult, results);
+        assertDeepEquals(expectedResult, results, true);
     }
 
     @Test

--- a/java/integTest/src/test/java/glide/standalone/TransactionTests.java
+++ b/java/integTest/src/test/java/glide/standalone/TransactionTests.java
@@ -2,6 +2,7 @@
 package glide.standalone;
 
 import static glide.TestConfiguration.REDIS_VERSION;
+import static glide.TestUtilities.assertDeepEquals;
 import static glide.api.BaseClient.OK;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -104,7 +105,7 @@ public class TransactionTests {
         Object[] expectedResult = builder.apply(transaction);
 
         Object[] results = client.exec(transaction).get();
-        assertArrayEquals(expectedResult, results);
+        assertDeepEquals(expectedResult, results, true);
     }
 
     @SneakyThrows
@@ -116,7 +117,7 @@ public class TransactionTests {
         Object[] expectedResult = builder.apply(transaction);
 
         Object[] results = client.exec(transaction).get();
-        assertArrayEquals(expectedResult, results);
+        assertDeepEquals(expectedResult, results, true);
     }
 
     @SneakyThrows


### PR DESCRIPTION
Add deep comparison for nested collections.
Standard `assertEquals` uses `equals` method co compare collection entries (map, lists, etc), which does not work when an entry stores an array.