### PR TITLE
Java: Add `FCALL` command.

### DIFF
--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -187,6 +187,7 @@ enum RequestType {
     GetBit = 145;
     ZInter = 146;
     FunctionLoad = 150;
+    FCall = 154;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -157,6 +157,7 @@ pub enum RequestType {
     GetBit = 145,
     ZInter = 146,
     FunctionLoad = 150,
+    FCall = 154,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -317,6 +318,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::GetBit => RequestType::GetBit,
             ProtobufRequestType::ZInter => RequestType::ZInter,
             ProtobufRequestType::FunctionLoad => RequestType::FunctionLoad,
+            ProtobufRequestType::FCall => RequestType::FCall,
         }
     }
 }
@@ -473,6 +475,7 @@ impl RequestType {
             RequestType::GetBit => Some(cmd("GETBIT")),
             RequestType::ZInter => Some(cmd("ZINTER")),
             RequestType::FunctionLoad => Some(get_two_word_command("FUNCTION", "LOAD")),
+            RequestType::FCall => Some(cmd("FCALL")),
         }
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -20,6 +20,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Del;
 import static redis_request.RedisRequestOuterClass.RequestType.Exists;
 import static redis_request.RedisRequestOuterClass.RequestType.Expire;
 import static redis_request.RedisRequestOuterClass.RequestType.ExpireAt;
+import static redis_request.RedisRequestOuterClass.RequestType.FCall;
 import static redis_request.RedisRequestOuterClass.RequestType.GeoAdd;
 import static redis_request.RedisRequestOuterClass.RequestType.GeoDist;
 import static redis_request.RedisRequestOuterClass.RequestType.GeoHash;
@@ -121,6 +122,7 @@ import glide.api.commands.GeospatialIndicesBaseCommands;
 import glide.api.commands.HashBaseCommands;
 import glide.api.commands.HyperLogLogBaseCommands;
 import glide.api.commands.ListBaseCommands;
+import glide.api.commands.ScriptingAndFunctionsBaseCommands;
 import glide.api.commands.SetBaseCommands;
 import glide.api.commands.SortedSetBaseCommands;
 import glide.api.commands.StreamBaseCommands;
@@ -181,7 +183,8 @@ public abstract class BaseClient
                 SortedSetBaseCommands,
                 StreamBaseCommands,
                 HyperLogLogBaseCommands,
-                GeospatialIndicesBaseCommands {
+                GeospatialIndicesBaseCommands,
+                ScriptingAndFunctionsBaseCommands {
 
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
@@ -1352,5 +1355,13 @@ public abstract class BaseClient
     public CompletableFuture<Long> getbit(@NonNull String key, long offset) {
         String[] arguments = new String[] {key, Long.toString(offset)};
         return commandManager.submitNewCommand(GetBit, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Object> fcall(
+            @NonNull String function, @NonNull String[] keys, @NonNull String[] arguments) {
+        String[] args =
+                concatenateArrays(new String[] {function, Long.toString(keys.length)}, keys, arguments);
+        return commandManager.submitNewCommand(FCall, args, this::handleObjectOrNullResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -203,4 +203,9 @@ public class RedisClient extends BaseClient
                 new String[] {FunctionLoadOptions.REPLACE.toString(), libraryCode},
                 this::handleStringResponse);
     }
+
+    @Override
+    public CompletableFuture<Object> fcall(@NonNull String function) {
+        return fcall(function, new String[0], new String[0]);
+    }
 }

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -12,7 +12,6 @@ import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.ConfigSet;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.Echo;
-import static redis_request.RedisRequestOuterClass.RequestType.FCall;
 import static redis_request.RedisRequestOuterClass.RequestType.FlushAll;
 import static redis_request.RedisRequestOuterClass.RequestType.FunctionLoad;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
@@ -203,11 +202,5 @@ public class RedisClient extends BaseClient
                 FunctionLoad,
                 new String[] {FunctionLoadOptions.REPLACE.toString(), libraryCode},
                 this::handleStringResponse);
-    }
-
-    @Override
-    public CompletableFuture<Object> fcall(@NonNull String function, @NonNull String[] arguments) {
-        String[] args = concatenateArrays(new String[] {function, "0"}, arguments);
-        return commandManager.submitNewCommand(FCall, args, this::handleObjectOrNullResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -12,6 +12,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.ConfigSet;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.Echo;
+import static redis_request.RedisRequestOuterClass.RequestType.FCall;
 import static redis_request.RedisRequestOuterClass.RequestType.FlushAll;
 import static redis_request.RedisRequestOuterClass.RequestType.FunctionLoad;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
@@ -202,5 +203,11 @@ public class RedisClient extends BaseClient
                 FunctionLoad,
                 new String[] {FunctionLoadOptions.REPLACE.toString(), libraryCode},
                 this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<Object> fcall(@NonNull String function, @NonNull String[] arguments) {
+        String[] args = concatenateArrays(new String[] {function, "0"}, arguments);
+        return commandManager.submitNewCommand(FCall, args, this::handleObjectOrNullResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -449,6 +449,16 @@ public class RedisClusterClient extends BaseClient
     }
 
     @Override
+    public CompletableFuture<Object> fcall(@NonNull String function) {
+        return fcall(function, new String[0]);
+    }
+
+    @Override
+    public CompletableFuture<Object> fcall(@NonNull String function, @NonNull Route route) {
+        return fcall(function, new String[0], route);
+    }
+
+    @Override
     public CompletableFuture<Object> fcall(@NonNull String function, @NonNull String[] arguments) {
         String[] args = concatenateArrays(new String[] {function, "0"}, arguments); // 0 - key count
         return commandManager.submitNewCommand(FCall, args, this::handleObjectOrNullResponse);

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -14,6 +14,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.ConfigSet;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.Echo;
+import static redis_request.RedisRequestOuterClass.RequestType.FCall;
 import static redis_request.RedisRequestOuterClass.RequestType.FlushAll;
 import static redis_request.RedisRequestOuterClass.RequestType.FunctionLoad;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
@@ -445,5 +446,18 @@ public class RedisClusterClient extends BaseClient
                 new String[] {FunctionLoadOptions.REPLACE.toString(), libraryCode},
                 route,
                 this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<Object> fcall(@NonNull String function, @NonNull String[] arguments) {
+        String[] args = concatenateArrays(new String[] {function, "0"}, arguments); // 0 - key count
+        return commandManager.submitNewCommand(FCall, args, this::handleObjectOrNullResponse);
+    }
+
+    @Override
+    public CompletableFuture<Object> fcall(
+            @NonNull String function, @NonNull String[] arguments, @NonNull Route route) {
+        String[] args = concatenateArrays(new String[] {function, "0"}, arguments); // 0 - key count
+        return commandManager.submitNewCommand(FCall, args, route, this::handleObjectOrNullResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsBaseCommands.java
@@ -1,0 +1,38 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Supports commands and transactions for the "Scripting and Function" group for standalone and
+ * cluster clients.
+ *
+ * @see <a href="https://redis.io/docs/latest/commands/?group=scripting">Scripting and Function
+ *     Commands</a>
+ */
+public interface ScriptingAndFunctionsBaseCommands {
+
+    /**
+     * Invokes a previously loaded function.
+     *
+     * @apiNote When in cluster mode
+     *     <ul>
+     *       <li>all <code>keys</code> must map to the same hash slot.
+     *       <li>and no <code>keys</code> are given, command will be routed to a random node.
+     *     </ul>
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
+     * @param keys An <code>array</code> of key names which <code>function</code> will work with.
+     * @param arguments An <code>array</code> of <code>function</code> arguments.
+     * @return A value depends on the function that was executed.
+     * @example
+     *     <pre>{@code
+     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
+     * Object response = client.fcall("Deep_Thought", new String[0], args).get();
+     * assert Object == 42;
+     * }</pre>
+     */
+    CompletableFuture<Object> fcall(String function, String[] keys, String[] arguments);
+}

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsBaseCommands.java
@@ -24,14 +24,14 @@ public interface ScriptingAndFunctionsBaseCommands {
      * @since Redis 7.0 and above.
      * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
      * @param function The function name.
-     * @param keys An <code>array</code> of key arguments accessed by the function.
+     * @param keys An <code>array</code> of keys accessed by the function.
      * @param arguments An <code>array</code> of <code>function</code> arguments.
      * @return The invoked function's return value.
      * @example
      *     <pre>{@code
      * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
      * Object response = client.fcall("Deep_Thought", new String[0], args).get();
-     * assert Object == 42;
+     * assert Object == 42L;
      * }</pre>
      */
     CompletableFuture<Object> fcall(String function, String[] keys, String[] arguments);

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsBaseCommands.java
@@ -18,15 +18,15 @@ public interface ScriptingAndFunctionsBaseCommands {
      * @apiNote When in cluster mode
      *     <ul>
      *       <li>all <code>keys</code> must map to the same hash slot.
-     *       <li>and no <code>keys</code> are given, command will be routed to a random node.
+     *       <li>if no <code>keys</code> are given, command will be routed to a random node.
      *     </ul>
      *
      * @since Redis 7.0 and above.
      * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
      * @param function The function name.
-     * @param keys An <code>array</code> of key names which <code>function</code> will work with.
+     * @param keys An <code>array</code> of key arguments accessed by the function.
      * @param arguments An <code>array</code> of <code>function</code> arguments.
-     * @return A value depends on the function that was executed.
+     * @return The invoked function's return value.
      * @example
      *     <pre>{@code
      * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
@@ -84,4 +84,41 @@ public interface ScriptingAndFunctionsClusterCommands {
      * }</pre>
      */
     CompletableFuture<String> functionLoadReplace(String libraryCode, Route route);
+
+    /**
+     * Invokes a previously loaded function.<br>
+     * The command will be routed to a random node.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
+     * @param arguments An <code>array</code> of <code>function</code> arguments.
+     * @return A value depends on the function that was executed.
+     * @example
+     *     <pre>{@code
+     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
+     * Object response = client.fcall("Deep_Thought", args).get();
+     * assert Object == 42;
+     * }</pre>
+     */
+    CompletableFuture<Object> fcall(String function, String[] arguments);
+
+    /**
+     * Invokes a previously loaded function.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
+     * @param arguments An <code>array</code> of <code>function</code> arguments.
+     * @param route Specifies the routing configuration for the command. The client will route the
+     *     command to the nodes defined by <code>route</code>.
+     * @return A value depends on the function that was executed.
+     * @example
+     *     <pre>{@code
+     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
+     * Object response = client.fcall("Deep_Thought", args).get();
+     * assert Object == 42;
+     * }</pre>
+     */
+    CompletableFuture<Object> fcall(String function, String[] arguments, Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
@@ -93,7 +93,7 @@ public interface ScriptingAndFunctionsClusterCommands {
      * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
      * @param function The function name.
      * @param arguments An <code>array</code> of <code>function</code> arguments.
-     * @return A value depends on the function that was executed.
+     * @return The invoked function's return value.
      * @example
      *     <pre>{@code
      * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
@@ -112,7 +112,7 @@ public interface ScriptingAndFunctionsClusterCommands {
      * @param arguments An <code>array</code> of <code>function</code> arguments.
      * @param route Specifies the routing configuration for the command. The client will route the
      *     command to the nodes defined by <code>route</code>.
-     * @return A value depends on the function that was executed.
+     * @return The invoked function's return value.
      * @example
      *     <pre>{@code
      * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
@@ -92,6 +92,39 @@ public interface ScriptingAndFunctionsClusterCommands {
      * @since Redis 7.0 and above.
      * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
      * @param function The function name.
+     * @return The invoked function's return value.
+     * @example
+     *     <pre>{@code
+     * Object response = client.fcall("Deep_Thought").get();
+     * assert Object == 42L;
+     * }</pre>
+     */
+    CompletableFuture<Object> fcall(String function);
+
+    /**
+     * Invokes a previously loaded function.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
+     * @param route Specifies the routing configuration for the command. The client will route the
+     *     command to the nodes defined by <code>route</code>.
+     * @return The invoked function's return value.
+     * @example
+     *     <pre>{@code
+     * Object response = client.fcall("Deep_Thought", ALL_NODES).get();
+     * assert Object == 42L;
+     * }</pre>
+     */
+    CompletableFuture<Object> fcall(String function, Route route);
+
+    /**
+     * Invokes a previously loaded function.<br>
+     * The command will be routed to a random node.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
      * @param arguments An <code>array</code> of <code>function</code> arguments.
      * @return The invoked function's return value.
      * @example

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
@@ -96,9 +96,9 @@ public interface ScriptingAndFunctionsClusterCommands {
      * @return The invoked function's return value.
      * @example
      *     <pre>{@code
-     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
+     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything" };
      * Object response = client.fcall("Deep_Thought", args).get();
-     * assert Object == 42;
+     * assert Object == 42L;
      * }</pre>
      */
     CompletableFuture<Object> fcall(String function, String[] arguments);
@@ -115,9 +115,9 @@ public interface ScriptingAndFunctionsClusterCommands {
      * @return The invoked function's return value.
      * @example
      *     <pre>{@code
-     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
-     * Object response = client.fcall("Deep_Thought", args).get();
-     * assert Object == 42;
+     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything" };
+     * Object response = client.fcall("Deep_Thought", args, ALL_NODES).get();
+     * assert Object == 42L;
      * }</pre>
      */
     CompletableFuture<Object> fcall(String function, String[] arguments, Route route);

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsCommands.java
@@ -4,8 +4,8 @@ package glide.api.commands;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Supports commands and transactions for the "Scripting and Function" group for standalone and
- * cluster clients.
+ * Supports commands and transactions for the "Scripting and Function" group for a standalone
+ * client.
  *
  * @see <a href="https://redis.io/docs/latest/commands/?group=scripting">Scripting and Function
  *     Commands</a>
@@ -44,4 +44,21 @@ public interface ScriptingAndFunctionsCommands {
      * }</pre>
      */
     CompletableFuture<String> functionLoadReplace(String libraryCode);
+
+    /**
+     * Invokes a previously loaded function.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
+     * @param arguments An <code>array</code> of <code>function</code> arguments.
+     * @return A value depends on the function that was executed.
+     * @example
+     *     <pre>{@code
+     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
+     * Object response = client.fcall("Deep_Thought", args).get();
+     * assert Object == 42;
+     * }</pre>
+     */
+    CompletableFuture<Object> fcall(String function, String[] arguments);
 }

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsCommands.java
@@ -44,21 +44,4 @@ public interface ScriptingAndFunctionsCommands {
      * }</pre>
      */
     CompletableFuture<String> functionLoadReplace(String libraryCode);
-
-    /**
-     * Invokes a previously loaded function.
-     *
-     * @since Redis 7.0 and above.
-     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
-     * @param function The function name.
-     * @param arguments An <code>array</code> of <code>function</code> arguments.
-     * @return A value depends on the function that was executed.
-     * @example
-     *     <pre>{@code
-     * String[] args = new String[] { "Answer", "to", "the", "Ultimate", "Question", "of", "Life,", "the", "Universe,", "and", "Everything"};
-     * Object response = client.fcall("Deep_Thought", args).get();
-     * assert Object == 42;
-     * }</pre>
-     */
-    CompletableFuture<Object> fcall(String function, String[] arguments);
 }

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsCommands.java
@@ -44,4 +44,19 @@ public interface ScriptingAndFunctionsCommands {
      * }</pre>
      */
     CompletableFuture<String> functionLoadReplace(String libraryCode);
+
+    /**
+     * Invokes a previously loaded function.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
+     * @return The invoked function's return value.
+     * @example
+     *     <pre>{@code
+     * Object response = client.fcall("Deep_Thought").get();
+     * assert Object == 42L;
+     * }</pre>
+     */
+    CompletableFuture<Object> fcall(String function);
 }

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -31,6 +31,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Echo;
 import static redis_request.RedisRequestOuterClass.RequestType.Exists;
 import static redis_request.RedisRequestOuterClass.RequestType.Expire;
 import static redis_request.RedisRequestOuterClass.RequestType.ExpireAt;
+import static redis_request.RedisRequestOuterClass.RequestType.FCall;
 import static redis_request.RedisRequestOuterClass.RequestType.FlushAll;
 import static redis_request.RedisRequestOuterClass.RequestType.FunctionLoad;
 import static redis_request.RedisRequestOuterClass.RequestType.GeoAdd;
@@ -3266,6 +3267,25 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     public T functionLoadReplace(@NonNull String libraryCode) {
         ArgsArray commandArgs = buildArgs(FunctionLoadOptions.REPLACE.toString(), libraryCode);
         protobufTransaction.addCommands(buildCommand(FunctionLoad, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Invokes a previously loaded function.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
+     * @param keys An <code>array</code> of key names which <code>function</code> will work with.
+     * @param arguments An <code>array</code> of <code>function</code> arguments.
+     * @return Command Response - A value depends on the function that was executed.
+     */
+    public T fcall(@NonNull String function, @NonNull String[] keys, @NonNull String[] arguments) {
+        ArgsArray commandArgs =
+                buildArgs(
+                        concatenateArrays(
+                                new String[] {function, Long.toString(keys.length)}, keys, arguments));
+        protobufTransaction.addCommands(buildCommand(FCall, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -3290,6 +3290,19 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
+     * Invokes a previously loaded function.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
+     * @param function The function name.
+     * @param arguments An <code>array</code> of <code>function</code> arguments.
+     * @return Command Response - The invoked function's return value.
+     */
+    public T fcall(@NonNull String function, @NonNull String[] arguments) {
+        return fcall(function, new String[0], arguments);
+    }
+
+    /**
      * Sets or clears the bit at <code>offset</code> in the string value stored at <code>key</code>.
      * The <code>offset</code> is a zero-based index, with <code>0</code> being the first element of
      * the list, <code>1</code> being the next element, and so on. The <code>offset</code> must be

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -3276,9 +3276,9 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @since Redis 7.0 and above.
      * @see <a href="https://redis.io/docs/latest/commands/fcall/">redis.io</a> for details.
      * @param function The function name.
-     * @param keys An <code>array</code> of key names which <code>function</code> will work with.
+     * @param keys An <code>array</code> of key arguments accessed by the function.
      * @param arguments An <code>array</code> of <code>function</code> arguments.
-     * @return Command Response - A value depends on the function that was executed.
+     * @return Command Response - The invoked function's return value.
      */
     public T fcall(@NonNull String function, @NonNull String[] keys, @NonNull String[] arguments) {
         ArgsArray commandArgs =

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -4481,7 +4481,7 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
-    public void fcall_returns_success() {
+    public void fcall_with_keys_and_args_returns_success() {
         // setup
         String function = "func";
         String[] keys = new String[] {"key1", "key2"};
@@ -4496,6 +4496,28 @@ public class RedisClientTest {
 
         // exercise
         CompletableFuture<Object> response = service.fcall(function, keys, arguments);
+        Object payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void fcall_returns_success() {
+        // setup
+        String function = "func";
+        String[] args = new String[] {function, "0"};
+        Object value = "42";
+        CompletableFuture<Object> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.submitNewCommand(eq(FCall), eq(args), any())).thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Object> response = service.fcall(function);
         Object payload = response.get();
 
         // verify

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -52,6 +52,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Echo;
 import static redis_request.RedisRequestOuterClass.RequestType.Exists;
 import static redis_request.RedisRequestOuterClass.RequestType.Expire;
 import static redis_request.RedisRequestOuterClass.RequestType.ExpireAt;
+import static redis_request.RedisRequestOuterClass.RequestType.FCall;
 import static redis_request.RedisRequestOuterClass.RequestType.FlushAll;
 import static redis_request.RedisRequestOuterClass.RequestType.FunctionLoad;
 import static redis_request.RedisRequestOuterClass.RequestType.GeoAdd;
@@ -4472,6 +4473,30 @@ public class RedisClientTest {
         // exercise
         CompletableFuture<String> response = service.functionLoadReplace(code);
         String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void fcall_returns_success() {
+        // setup
+        String function = "func";
+        String[] keys = new String[0];
+        String[] arguments = new String[] {"1", "2"};
+        String[] args = new String[] {function, "0", "1", "2"};
+        Object value = "42";
+        CompletableFuture<Object> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.submitNewCommand(eq(FCall), eq(args), any())).thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Object> response = service.fcall(function, keys, arguments);
+        Object payload = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -4484,9 +4484,9 @@ public class RedisClientTest {
     public void fcall_returns_success() {
         // setup
         String function = "func";
-        String[] keys = new String[0];
+        String[] keys = new String[] {"key1", "key2"};
         String[] arguments = new String[] {"1", "2"};
-        String[] args = new String[] {function, "0", "1", "2"};
+        String[] args = new String[] {function, "2", "key1", "key2", "1", "2"};
         Object value = "42";
         CompletableFuture<Object> testResponse = new CompletableFuture<>();
         testResponse.complete(value);

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -1173,6 +1173,51 @@ public class RedisClusterClientTest {
 
     @SneakyThrows
     @Test
+    public void fcall_without_keys_and_without_args_returns_success() {
+        // setup
+        String function = "func";
+        String[] args = new String[] {function, "0"};
+        Object value = "42";
+        CompletableFuture<Object> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.submitNewCommand(eq(FCall), eq(args), any())).thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Object> response = service.fcall(function);
+        Object payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void fcall_without_keys_and_without_args_but_with_route_returns_success() {
+        // setup
+        String function = "func";
+        String[] args = new String[] {function, "0"};
+        Object value = "42";
+        CompletableFuture<Object> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.submitNewCommand(eq(FCall), eq(args), eq(RANDOM), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Object> response = service.fcall(function, RANDOM);
+        Object payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
     public void fcall_without_keys_returns_success() {
         // setup
         String function = "func";

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -22,6 +22,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.ConfigResetStat;
 import static redis_request.RedisRequestOuterClass.RequestType.ConfigRewrite;
 import static redis_request.RedisRequestOuterClass.RequestType.ConfigSet;
 import static redis_request.RedisRequestOuterClass.RequestType.Echo;
+import static redis_request.RedisRequestOuterClass.RequestType.FCall;
 import static redis_request.RedisRequestOuterClass.RequestType.FlushAll;
 import static redis_request.RedisRequestOuterClass.RequestType.FunctionLoad;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
@@ -1164,6 +1165,53 @@ public class RedisClusterClientTest {
         // exercise
         CompletableFuture<String> response = service.functionLoadReplace(code, RANDOM);
         String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void fcall_without_keys_returns_success() {
+        // setup
+        String function = "func";
+        String[] arguments = new String[] {"1", "2"};
+        String[] args = new String[] {function, "0", "1", "2"};
+        Object value = "42";
+        CompletableFuture<Object> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.submitNewCommand(eq(FCall), eq(args), any())).thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Object> response = service.fcall(function, arguments);
+        Object payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void fcall_without_keys_and_with_route_returns_success() {
+        // setup
+        String function = "func";
+        String[] arguments = new String[] {"1", "2"};
+        String[] args = new String[] {function, "0", "1", "2"};
+        Object value = "42";
+        CompletableFuture<Object> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.submitNewCommand(eq(FCall), eq(args), eq(RANDOM), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Object> response = service.fcall(function, arguments, RANDOM);
+        Object payload = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -774,6 +774,9 @@ public class TransactionTests {
         transaction.fcall("func", new String[] {"key1", "key2"}, new String[] {"arg1", "arg2"});
         results.add(Pair.of(FCall, buildArgs("func", "2", "key1", "key2", "arg1", "arg2")));
 
+        transaction.fcall("func", new String[] {"arg1", "arg2"});
+        results.add(Pair.of(FCall, buildArgs("func", "0", "arg1", "arg2")));
+
         transaction.geodist("key", "Place", "Place2");
         results.add(Pair.of(GeoDist, buildArgs("key", "Place", "Place2")));
         transaction.geodist("key", "Place", "Place2", GeoUnit.KILOMETERS);

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -42,6 +42,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Echo;
 import static redis_request.RedisRequestOuterClass.RequestType.Exists;
 import static redis_request.RedisRequestOuterClass.RequestType.Expire;
 import static redis_request.RedisRequestOuterClass.RequestType.ExpireAt;
+import static redis_request.RedisRequestOuterClass.RequestType.FCall;
 import static redis_request.RedisRequestOuterClass.RequestType.FlushAll;
 import static redis_request.RedisRequestOuterClass.RequestType.FunctionLoad;
 import static redis_request.RedisRequestOuterClass.RequestType.GeoAdd;
@@ -769,6 +770,9 @@ public class TransactionTests {
         transaction.functionLoad("pewpew").functionLoadReplace("ololo");
         results.add(Pair.of(FunctionLoad, buildArgs("pewpew")));
         results.add(Pair.of(FunctionLoad, buildArgs("REPLACE", "ololo")));
+
+        transaction.fcall("func", new String[] {"key1", "key2"}, new String[] {"arg1", "arg2"});
+        results.add(Pair.of(FCall, buildArgs("func", "2", "key1", "key2", "arg1", "arg2")));
 
         transaction.geodist("key", "Place", "Place2");
         results.add(Pair.of(GeoDist, buildArgs("key", "Place", "Place2")));

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -123,4 +123,22 @@ public class TestUtilities {
             assertEquals(expected, actual);
         }
     }
+
+    /** Generate a LUA library code. */
+    public static String generateLuaLibCode(
+            String libName, Map<String, String> functions, boolean readonly) {
+        StringBuilder code = new StringBuilder("#!lua name=" + libName + "\n");
+        for (var function : functions.entrySet()) {
+            code.append("redis.register_function{ function_name = '")
+                    .append(function.getKey())
+                    .append("', callback = function(keys, args) ")
+                    .append(function.getValue())
+                    .append(" end");
+            if (readonly) {
+                code.append(", flags = { 'no-writes' }");
+            }
+            code.append(" }\n");
+        }
+        return code.toString();
+    }
 }

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -521,19 +521,21 @@ public class TransactionTestUtilities {
         }
 
         final String code =
-                "#!lua name=mylib1T \n"
-                        + " redis.register_function('myfunc1T',"
+                "#!lua name=mylib1T\n"
+                        + "redis.register_function('myfunc1T',"
                         + "function(keys, args) return args[1] end)"; // function returns first argument
 
         transaction
                 .functionLoad(code)
                 .functionLoadReplace(code)
-                .fcall("myfunc1T", new String[0], new String[] {"a", "b"});
+                .fcall("myfunc1T", new String[0], new String[] {"a", "b"})
+                .fcall("myfunc1T", new String[] {"a", "b"});
 
         return new Object[] {
             "mylib1T", // functionLoad(code)
             "mylib1T", // functionLoadReplace(code)
             "a", // fcall("myfunc1T", new String[0], new String[]{"a", "b"})
+            "a", // fcall("myfunc1T", new String[] {"a", "b"})
         };
     }
 

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -522,7 +522,8 @@ public class TransactionTestUtilities {
 
         final String code =
                 "#!lua name=mylib1T \n"
-                        + " redis.register_function('myfunc1T', function(keys, args) return args[1] end)";
+                        + " redis.register_function('myfunc1T',"
+                        + "function(keys, args) return args[1] end)"; // function returns first argument
 
         transaction
                 .functionLoad(code)

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -524,11 +524,15 @@ public class TransactionTestUtilities {
                 "#!lua name=mylib1T \n"
                         + " redis.register_function('myfunc1T', function(keys, args) return args[1] end)";
 
-        transaction.functionLoad(code).functionLoadReplace(code);
+        transaction
+                .functionLoad(code)
+                .functionLoadReplace(code)
+                .fcall("myfunc1T", new String[0], new String[] {"a", "b"});
 
         return new Object[] {
             "mylib1T", // functionLoad(code)
-            "mylib1T" // functionLoadReplace(code)
+            "mylib1T", // functionLoadReplace(code)
+            "a", // fcall("myfunc1T", new String[0], new String[]{"a", "b"})
         };
     }
 

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -807,7 +807,8 @@ public class CommandTests {
                         + libName
                         + " \n redis.register_function('"
                         + funcName
-                        + "', function(keys, args) return args[1] end)"; // function returns first argument
+                        + "', flags={ 'no-writes' },"
+                        + "function(keys, args) return args[1] end)"; // function returns first argument
 
         assertEquals(libName, clusterClient.functionLoad(code).get());
 
@@ -829,7 +830,8 @@ public class CommandTests {
                 code
                         + "\n redis.register_function('"
                         + newFuncName
-                        + "', function(keys, args) return #args end)"; // function returns argument array len
+                        + "', flags={ 'no-writes' },"
+                        + "function(keys, args) return #args end)"; // function returns argument array len
 
         assertEquals(libName, clusterClient.functionLoadReplace(newCode).get());
 

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -825,6 +825,7 @@ public class CommandTests {
         assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0"), "This feature added in redis 7");
 
         prefix = "{" + prefix + "}-fcall_with_keys-";
+        Route route = new SlotKeyRoute(prefix, PRIMARY);
         String libName = "mylib_with_keys";
         String funcName = "myfunc_with_keys";
         String code =
@@ -833,13 +834,13 @@ public class CommandTests {
                         + " \n redis.register_function('"
                         + funcName
                         + "', function(keys, args) return {keys[1], keys[2]} end)";
-        assertEquals(libName, clusterClient.functionLoad(code, ALL_NODES).get());
+        assertEquals(libName, clusterClient.functionLoad(code, route).get());
 
         var functionResult =
                 clusterClient.fcall(funcName, new String[] {prefix + 1, prefix + 2}, new String[0]).get();
         assertArrayEquals(new Object[] {prefix + 1, prefix + 2}, (Object[]) functionResult);
 
         // TODO replace with command
-        clusterClient.customCommand(new String[] {"function", "delete", libName}, ALL_NODES).get();
+        clusterClient.customCommand(new String[] {"function", "delete", libName}, route).get();
     }
 }

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -805,10 +805,12 @@ public class CommandTests {
         String code =
                 "#!lua name="
                         + libName
-                        + " \n redis.register_function('"
+                        + " \n redis.register_function{"
+                        + "function_name = '"
                         + funcName
-                        + "', flags={ 'no-writes' },"
-                        + "function(keys, args) return args[1] end)"; // function returns first argument
+                        + "', callback = function(keys, args) return args[1] end" // function returns first
+                        // argument
+                        + ", flags = { 'no-writes' }}";
 
         assertEquals(libName, clusterClient.functionLoad(code).get());
 
@@ -828,10 +830,12 @@ public class CommandTests {
         String newFuncName = "myfunc2c";
         String newCode =
                 code
-                        + "\n redis.register_function('"
+                        + "\n redis.register_function{"
+                        + "function_name = '"
                         + newFuncName
-                        + "', flags={ 'no-writes' },"
-                        + "function(keys, args) return #args end)"; // function returns argument array len
+                        + "', callback = function(keys, args) return #args end" // function returns argument
+                        // array len
+                        + ", flags = { 'no-writes' }}";
 
         assertEquals(libName, clusterClient.functionLoadReplace(newCode).get());
 

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -803,7 +803,8 @@ public class CommandTests {
         String libName = "mylib1c";
         String funcName = "myfunc1c";
         // function $funcName returns first argument
-        // generating RO functions to execution on a replica (default routing goes to RANDOM including replicas)
+        // generating RO functions to execution on a replica (default routing goes to RANDOM including
+        // replicas)
         String code = generateLuaLibCode(libName, Map.of(funcName, "return args[1]"), true);
 
         assertEquals(libName, clusterClient.functionLoad(code).get());

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -339,7 +339,7 @@ public class CommandTests {
 
     @SneakyThrows
     @Test
-    public void functionLoad() {
+    public void functionLoad_and_fcall() {
         assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0"), "This feature added in redis 7");
         String libName = "mylib1C";
         String code =
@@ -347,7 +347,11 @@ public class CommandTests {
                         + libName
                         + " \n redis.register_function('myfunc1c', function(keys, args) return args[1] end)";
         assertEquals(libName, regularClient.functionLoad(code).get());
-        // TODO test function with FCALL when fixed in redis-rs and implemented
+
+        var functionResult =
+                regularClient.fcall("myfunc1c", new String[0], new String[] {"one", "two"}).get();
+        assertEquals("one", functionResult);
+
         // TODO test with FUNCTION LIST
 
         // re-load library without overwriting
@@ -362,6 +366,9 @@ public class CommandTests {
         String newCode =
                 code + "\n redis.register_function('myfunc2c', function(keys, args) return #args end)";
         assertEquals(libName, regularClient.functionLoadReplace(newCode).get());
-        // TODO test with FCALL
+
+        functionResult =
+                regularClient.fcall("myfunc2c", new String[0], new String[] {"one", "two"}).get();
+        assertEquals(2L, functionResult);
     }
 }


### PR DESCRIPTION
https://redis.io/docs/latest/commands/fcall/

**Some details**
common interface functions
```js
Object fcall(String function, String[] keys, String[] arguments);
```
standalone interface functions
```js
Object fcall(String function);
```
cluster interface functions
```js
Object fcall(String function);
Object fcall(String function, Route route);
Object fcall(String function, String[] arguments);
Object fcall(String function, String[] arguments, Route route);
```

**This results in**

standalone client functions
```js
Object fcall(String function);
Object fcall(String function, String[] keys, String[] arguments);
```
cluster client functions
```js
Object fcall(String function); // routed to a random node
Object fcall(String function, Route route); // routed according to the given route
Object fcall(String function, String[] arguments); // routed to a random node
Object fcall(String function, String[] arguments, Route route); // routed according to the given route
Object fcall(String function, String[] keys, String[] arguments); // routed according to the given keys
```

transaction functions
```js
Object fcall(String function, String[] keys, String[] arguments);
Object fcall(String function, String[] arguments);
```


