### PR TITLE
Python: add OBJECT ENCODING command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Python: Added SDIFFSTORE command ([#1449](https://github.com/aws/glide-for-redis/pull/1449))
 * Python: Added SINTERSTORE command ([#1459](https://github.com/aws/glide-for-redis/pull/1459))
 * Python: Added SMISMEMBER command ([#1461](https://github.com/aws/glide-for-redis/pull/1461))
+* Python: Added OBJECT ENCODING command (TODO: add PR link)
 
 
 #### Fixes

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -3456,3 +3456,25 @@ class CoreCommands(Protocol):
             int,
             await self._execute_command(RequestType.PfAdd, [key] + elements),
         )
+
+    async def object_encoding(self, key: str) -> Optional[str]:
+        """
+        Returns the internal encoding for the Redis object stored at `key`.
+
+        See https://valkey.io/commands/object-encoding for more details.
+
+        Args:
+            key (str): The `key` of the object to get the internal encoding of.
+
+        Returns:
+            Optional[str]: If `key` exists, returns the internal encoding of the object stored at
+                `key` as a string. Otherwise, returns None.
+
+        Examples:
+            >>> await client.object_encoding("my_hash")
+                "listpack"  # The hash stored at "my_hash" has an internal encoding of "listpack".
+        """
+        return cast(
+            Optional[str],
+            await self._execute_command(RequestType.ObjectEncoding, [key]),
+        )

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2413,6 +2413,21 @@ class BaseTransaction:
         """
         return self.append_command(RequestType.PfAdd, [key] + elements)
 
+    def object_encoding(self: TTransaction, key: str) -> TTransaction:
+        """
+        Returns the internal encoding for the Redis object stored at `key`.
+
+        See https://valkey.io/commands/object-encoding for more details.
+
+        Args:
+            key (str): The `key` of the object to get the internal encoding of.
+
+        Command response:
+            Optional[str]: If `key` exists, returns the internal encoding of the object stored at
+                `key` as a string. Otherwise, returns None.
+        """
+        return self.append_command(RequestType.ObjectEncoding, [key])
+
 
 class Transaction(BaseTransaction):
     """

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -3269,6 +3269,79 @@ class TestCommands:
         with pytest.raises(RequestError):
             await redis_client.pfadd("foo", [])
 
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_object_encoding(self, redis_client: TRedisClient):
+        string_key = get_random_string(10)
+        list_key = get_random_string(10)
+        hashtable_key = get_random_string(10)
+        intset_key = get_random_string(10)
+        set_listpack_key = get_random_string(10)
+        hash_hashtable_key = get_random_string(10)
+        hash_listpack_key = get_random_string(10)
+        skiplist_key = get_random_string(10)
+        zset_listpack_key = get_random_string(10)
+        stream_key = get_random_string(10)
+        non_existing_key = get_random_string(10)
+
+        assert await redis_client.object_encoding(non_existing_key) is None
+
+        assert await redis_client.set(
+            string_key, "a really loooooooooooooooooooooooooooooooooooooooong value"
+        )
+        assert await redis_client.object_encoding(string_key) == "raw"
+
+        assert await redis_client.set(string_key, "2") == OK
+        assert await redis_client.object_encoding(string_key) == "int"
+
+        assert await redis_client.set(string_key, "value") == OK
+        assert await redis_client.object_encoding(string_key) == "embstr"
+
+        assert await redis_client.lpush(list_key, ["1"]) == 1
+        if await check_if_server_version_lt(redis_client, "7.0.0"):
+            assert await redis_client.object_encoding(list_key) == "quicklist"
+        else:
+            assert await redis_client.object_encoding(list_key) == "listpack"
+
+        # The default value of set-max-intset-entries is 512
+        for i in range(0, 513):
+            assert await redis_client.sadd(hashtable_key, [str(i)]) == 1
+        assert await redis_client.object_encoding(hashtable_key) == "hashtable"
+
+        assert await redis_client.sadd(intset_key, ["1"]) == 1
+        assert await redis_client.object_encoding(intset_key) == "intset"
+
+        assert await redis_client.sadd(set_listpack_key, ["foo"]) == 1
+        if await check_if_server_version_lt(redis_client, "7.2.0"):
+            assert await redis_client.object_encoding(set_listpack_key) == "hashtable"
+        else:
+            assert await redis_client.object_encoding(set_listpack_key) == "listpack"
+
+        # The default value of hash-max-listpack-entries is 512
+        for i in range(0, 513):
+            assert await redis_client.hset(hash_hashtable_key, {str(i): "2"}) == 1
+        assert await redis_client.object_encoding(hash_hashtable_key) == "hashtable"
+
+        assert await redis_client.hset(hash_listpack_key, {"1": "2"}) == 1
+        if await check_if_server_version_lt(redis_client, "7.0.0"):
+            assert await redis_client.object_encoding(hash_listpack_key) == "ziplist"
+        else:
+            assert await redis_client.object_encoding(hash_listpack_key) == "listpack"
+
+        # The default value of zset-max-listpack-entries is 128
+        for i in range(0, 129):
+            assert await redis_client.zadd(skiplist_key, {str(i): 2.0}) == 1
+        assert await redis_client.object_encoding(skiplist_key) == "skiplist"
+
+        assert await redis_client.zadd(zset_listpack_key, {"1": 2.0}) == 1
+        if await check_if_server_version_lt(redis_client, "7.0.0"):
+            assert await redis_client.object_encoding(zset_listpack_key) == "ziplist"
+        else:
+            assert await redis_client.object_encoding(zset_listpack_key) == "listpack"
+
+        assert await redis_client.xadd(stream_key, [("field", "value")]) is not None
+        assert await redis_client.object_encoding(stream_key) == "stream"
+
 
 class TestMultiKeyCommandCrossSlot:
     @pytest.mark.parametrize("cluster_mode", [True])
@@ -3296,7 +3369,7 @@ class TestMultiKeyCommandCrossSlot:
             redis_client.sdiffstore("abc", ["def", "ghi"]),
         ]
 
-        if not check_if_server_version_lt(redis_client, "7.0.0"):
+        if not await check_if_server_version_lt(redis_client, "7.0.0"):
             promises.extend(
                 [
                     redis_client.bzmpop(["abc", "zxy", "lkn"], ScoreFilter.MAX, 0.1),

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -63,6 +63,8 @@ async def transaction_test(
 
     transaction.set(key, value)
     args.append(OK)
+    transaction.object_encoding(key)
+    args.append("embstr")
     transaction.get(key)
     args.append(value)
     transaction.type(key)


### PR DESCRIPTION
https://redis.io/docs/latest/commands/object-encoding/

Implementation and tests based on Java implementation:
https://github.com/aws/glide-for-redis/pull/1313