### PR TITLE
Fix rust linter CI.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,9 +88,11 @@ jobs:
             - uses: ./.github/workflows/lint-rust
               with:
                   cargo-toml-folder: ./logger_core
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
               name: lint logger
 
             - uses: ./.github/workflows/lint-rust
               with:
                   cargo-toml-folder: ./benchmarks/rust
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
               name: lint benchmark


### PR DESCRIPTION
Add missing GH token to avoid `rate exceeded` error for non authenticated requests
https://github.com/aws/glide-for-redis/actions/runs/9227667494/job/25390082670?pr=1460

```
Prepare all required actions
Getting action download info
Run ./.github/workflows/lint-rust
Run actions/checkout@v4
Syncing repository: aws/glide-for-redis
...
...
Run arduino/setup-protoc@v3
Error: Error: API rate limit exceeded for 20.161.76.225. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```