### PR TITLE
Java: Update `ZUNION` and `ZINTER` and tests.

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -1163,7 +1163,7 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<String[]> zunion(KeyArray keys) {
+    public CompletableFuture<String[]> zunion(@NonNull KeyArray keys) {
         return commandManager.submitNewCommand(
                 ZUnion, keys.toArgs(), response -> castArray(handleArrayResponse(response), String.class));
     }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -166,6 +166,7 @@ import glide.api.models.commands.ScoreFilter;
 import glide.api.models.commands.ScriptOptions;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.WeightAggregateOptions.Aggregate;
+import glide.api.models.commands.WeightAggregateOptions.KeyArray;
 import glide.api.models.commands.WeightAggregateOptions.KeysOrWeightedKeys;
 import glide.api.models.commands.ZAddOptions;
 import glide.api.models.commands.bitmap.BitmapIndexType;
@@ -1162,19 +1163,9 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<String[]> zunion(
-            @NonNull KeysOrWeightedKeys keysOrWeightedKeys, @NonNull Aggregate aggregate) {
-        String[] arguments = concatenateArrays(keysOrWeightedKeys.toArgs(), aggregate.toArgs());
+    public CompletableFuture<String[]> zunion(KeyArray keys) {
         return commandManager.submitNewCommand(
-                ZUnion, arguments, response -> castArray(handleArrayResponse(response), String.class));
-    }
-
-    @Override
-    public CompletableFuture<String[]> zunion(@NonNull KeysOrWeightedKeys keysOrWeightedKeys) {
-        return commandManager.submitNewCommand(
-                ZUnion,
-                keysOrWeightedKeys.toArgs(),
-                response -> castArray(handleArrayResponse(response), String.class));
+                ZUnion, keys.toArgs(), response -> castArray(handleArrayResponse(response), String.class));
     }
 
     @Override
@@ -1195,19 +1186,9 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<String[]> zinter(
-            @NonNull KeysOrWeightedKeys keysOrWeightedKeys, @NonNull Aggregate aggregate) {
-        String[] arguments = concatenateArrays(keysOrWeightedKeys.toArgs(), aggregate.toArgs());
+    public CompletableFuture<String[]> zinter(@NonNull KeyArray keys) {
         return commandManager.submitNewCommand(
-                ZInter, arguments, response -> castArray(handleArrayResponse(response), String.class));
-    }
-
-    @Override
-    public CompletableFuture<String[]> zinter(@NonNull KeysOrWeightedKeys keysOrWeightedKeys) {
-        return commandManager.submitNewCommand(
-                ZInter,
-                keysOrWeightedKeys.toArgs(),
-                response -> castArray(handleArrayResponse(response), String.class));
+                ZInter, keys.toArgs(), response -> castArray(handleArrayResponse(response), String.class));
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
@@ -672,6 +672,7 @@ public interface SortedSetBaseCommands {
      * To get the elements with their scores, see {@link #zdiffWithScores}.
      *
      * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zdiff/">redis.io</a> for more details.
      * @param keys The keys of the sorted sets.
      * @return An <code>array</code> of elements representing the difference between the sorted sets.
@@ -690,6 +691,7 @@ public interface SortedSetBaseCommands {
      * Returns the difference between the first sorted set and all the successive sorted sets.
      *
      * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zdiff/">redis.io</a> for more details.
      * @param keys The keys of the sorted sets.
      * @return A <code>Map</code> of elements and their scores representing the difference between the
@@ -711,6 +713,7 @@ public interface SortedSetBaseCommands {
      *
      * @apiNote When in cluster mode, <code>destination</code> and all <code>keys</code> must map to
      *     the same hash slot.
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zdiffstore/">redis.io</a> for more details.
      * @param destination The key for the resulting sorted set.
      * @param keys The keys of the sorted sets to compare.
@@ -1083,51 +1086,13 @@ public interface SortedSetBaseCommands {
             String[] keys, ScoreFilter modifier, double timeout, long count);
 
     /**
-     * Returns the union of members from sorted sets specified by the given <code>keysOrWeightedKeys
-     * </code>.<br>
+     * Returns the union of members from sorted sets specified by the given <code>keys</code>.<br>
      * To get the elements with their scores, see {@link #zunionWithScores}.
      *
-     * @apiNote When in cluster mode, all keys in <code>keysOrWeightedKeys</code> must map to the same
-     *     hash slot.
+     * @apiNote When in cluster mode, all keys in <code>keys</code> must map to the same hash slot.
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
-     * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
-     *     <ul>
-     *       <li>Use {@link KeyArray} for keys only.
-     *       <li>Use {@link WeightedKeys} for weighted keys with score multipliers.
-     *     </ul>
-     *
-     * @param aggregate Specifies the aggregation strategy to apply when combining the scores of
-     *     elements.
-     * @return The resulting sorted set from the union.
-     * @example
-     *     <pre>{@code
-     * KeyArray keyArray = new KeyArray(new String[] {"mySortedSet1", "mySortedSet2"});
-     * String[] payload = client.zunion(keyArray, Aggregate.MAX).get()
-     * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
-     *
-     * WeightedKeys weightedKeys = new WeightedKeys(List.of(Pair.of("mySortedSet1", 2.0), Pair.of("mySortedSet2", 2.0)));
-     * String[] payload = client.zunion(weightedKeys, Aggregate.MAX).get()
-     * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
-     * }</pre>
-     */
-    CompletableFuture<String[]> zunion(KeysOrWeightedKeys keysOrWeightedKeys, Aggregate aggregate);
-
-    /**
-     * Returns the union of members from sorted sets specified by the given <code>keysOrWeightedKeys
-     * </code>.<br>
-     * To perform a <code>zunion</code> operation while specifying aggregation settings, use {@link
-     * #zunion(KeysOrWeightedKeys, Aggregate)}.<br>
-     * To get the elements with their scores, see {@link #zunionWithScores}.
-     *
-     * @apiNote When in cluster mode, all keys in <code>keysOrWeightedKeys</code> must map to the same
-     *     hash slot.
-     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
-     * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
-     *     <ul>
-     *       <li>Use {@link KeyArray} for keys only.
-     *       <li>Use {@link WeightedKeys} for weighted keys with score multipliers.
-     *     </ul>
-     *
+     * @param keys The keys of the sorted sets.
      * @return The resulting sorted set from the union.
      * @example
      *     <pre>{@code
@@ -1140,7 +1105,7 @@ public interface SortedSetBaseCommands {
      * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
      * }</pre>
      */
-    CompletableFuture<String[]> zunion(KeysOrWeightedKeys keysOrWeightedKeys);
+    CompletableFuture<String[]> zunion(KeyArray keys);
 
     /**
      * Returns the union of members and their scores from sorted sets specified by the given <code>
@@ -1148,6 +1113,7 @@ public interface SortedSetBaseCommands {
      *
      * @apiNote When in cluster mode, all keys in <code>keysOrWeightedKeys</code> must map to the same
      *     hash slot.
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
      *     <ul>
@@ -1180,6 +1146,7 @@ public interface SortedSetBaseCommands {
      *
      * @apiNote When in cluster mode, all keys in <code>keysOrWeightedKeys</code> must map to the same
      *     hash slot.
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
      *     <ul>
@@ -1202,22 +1169,14 @@ public interface SortedSetBaseCommands {
     CompletableFuture<Map<String, Double>> zunionWithScores(KeysOrWeightedKeys keysOrWeightedKeys);
 
     /**
-     * Returns the intersection of members from sorted sets specified by the given <code>
-     * keysOrWeightedKeys</code>.<br>
-     * To perform a <code>zinter</code> operation while specifying aggregation settings, use {@link
-     * #zinter(KeysOrWeightedKeys, Aggregate)}.<br>
+     * Returns the intersection of members from sorted sets specified by the given <code>keys</code>.
+     * <br>
      * To get the elements with their scores, see {@link #zinterWithScores}.
      *
-     * @apiNote When in cluster mode, all keys in <code>keysOrWeightedKeys</code> must map to the same
-     *     hash slot.
+     * @apiNote When in cluster mode, all keys in <code>keys</code> must map to the same hash slot.
      * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zinter/">redis.io</a> for more details.
-     * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
-     *     <ul>
-     *       <li>Use {@link KeyArray} for keys only.
-     *       <li>Use {@link WeightedKeys} for weighted keys with score multipliers.
-     *     </ul>
-     *
+     * @param keys The keys of the sorted sets.
      * @return The resulting sorted set from the intersection.
      * @example
      *     <pre>{@code
@@ -1230,38 +1189,7 @@ public interface SortedSetBaseCommands {
      * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
      * }</pre>
      */
-    CompletableFuture<String[]> zinter(KeysOrWeightedKeys keysOrWeightedKeys);
-
-    /**
-     * Returns the intersection of members from sorted sets specified by the given <code>
-     * keysOrWeightedKeys</code>. To get the elements with their scores, see {@link
-     * #zinterWithScores}.
-     *
-     * @apiNote When in cluster mode, all keys in <code>keysOrWeightedKeys</code> must map to the same
-     *     hash slot.
-     * @since Redis 6.2 and above.
-     * @see <a href="https://redis.io/commands/zinter/">redis.io</a> for more details.
-     * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
-     *     <ul>
-     *       <li>Use {@link KeyArray} for keys only.
-     *       <li>Use {@link WeightedKeys} for weighted keys with score multipliers.
-     *     </ul>
-     *
-     * @param aggregate Specifies the aggregation strategy to apply when combining the scores of
-     *     elements.
-     * @return The resulting sorted set from the intersection.
-     * @example
-     *     <pre>{@code
-     * KeyArray keyArray = new KeyArray(new String[] {"mySortedSet1", "mySortedSet2"});
-     * String[] payload = client.zinter(keyArray, Aggregate.MAX).get()
-     * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
-     *
-     * WeightedKeys weightedKeys = new WeightedKeys(List.of(Pair.of("mySortedSet1", 2.0), Pair.of("mySortedSet2", 2.0)));
-     * String[] payload = client.zinter(weightedKeys, Aggregate.MAX).get()
-     * assert payload.equals(new String[] {"elem1", "elem2", "elem3"});
-     * }</pre>
-     */
-    CompletableFuture<String[]> zinter(KeysOrWeightedKeys keysOrWeightedKeys, Aggregate aggregate);
+    CompletableFuture<String[]> zinter(KeyArray keys);
 
     /**
      * Returns the intersection of members and their scores from sorted sets specified by the given

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -2473,8 +2473,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Returns the union of members from sorted sets specified by the given <code>keys
-     * </code>.<br>
+     * Returns the union of members from sorted sets specified by the given <code>keys</code>.<br>
      * To get the elements with their scores, see {@link #zunionWithScores}.
      *
      * @since Redis 6.2 and above.
@@ -2541,8 +2540,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Returns the intersection of members from sorted sets specified by the given <code>
-     * keys</code>.<br>
+     * Returns the intersection of members from sorted sets specified by the given <code>keys</code>.
+     * <br>
      * To get the elements with their scores, see {@link #zinterWithScores}.
      *
      * @since Redis 6.2 and above.

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -2102,6 +2102,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the difference between the first sorted set and all the successive sorted sets.<br>
      * To get the elements with their scores, see {@link #zdiffWithScores}.
      *
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zdiff/">redis.io</a> for more details.
      * @param keys The keys of the sorted sets.
      * @return Command Response - An <code>array</code> of elements representing the difference
@@ -2118,6 +2119,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the difference between the first sorted set and all the successive sorted sets.
      *
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zdiff/">redis.io</a> for more details.
      * @param keys The keys of the sorted sets.
      * @return Command Response - A <code>Map</code> of elements and their scores representing the
@@ -2138,6 +2140,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * <code>keys</code> and stores the difference as a sorted set to <code>destination</code>,
      * overwriting it if it already exists. Non-existent keys are treated as empty sets.
      *
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zdiffstore/">redis.io</a> for more details.
      * @param destination The key for the resulting sorted set.
      * @param keys The keys of the sorted sets to compare.
@@ -2470,46 +2473,17 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Returns the union of members from sorted sets specified by the given <code>keysOrWeightedKeys
+     * Returns the union of members from sorted sets specified by the given <code>keys
      * </code>.<br>
      * To get the elements with their scores, see {@link #zunionWithScores}.
      *
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
-     * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
-     *     <ul>
-     *       <li>Use {@link KeyArray} for keys only.
-     *       <li>Use {@link WeightedKeys} for weighted keys with score multipliers.
-     *     </ul>
-     *
-     * @param aggregate Specifies the aggregation strategy to apply when combining the scores of
-     *     elements.
+     * @param keys The keys of the sorted sets.
      * @return Command Response - The resulting sorted set from the union.
      */
-    public T zunion(@NonNull KeysOrWeightedKeys keysOrWeightedKeys, @NonNull Aggregate aggregate) {
-        ArgsArray commandArgs =
-                buildArgs(concatenateArrays(keysOrWeightedKeys.toArgs(), aggregate.toArgs()));
-        protobufTransaction.addCommands(buildCommand(ZUnion, commandArgs));
-        return getThis();
-    }
-
-    /**
-     * Returns the union of members from sorted sets specified by the given <code>keysOrWeightedKeys
-     * </code>.<br>
-     * To perform a <code>zunion</code> operation while specifying aggregation settings, use {@link
-     * #zunion(KeysOrWeightedKeys, Aggregate)}.<br>
-     * To get the elements with their scores, see {@link #zunionWithScores}.
-     *
-     * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
-     * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
-     *     <ul>
-     *       <li>Use {@link KeyArray} for keys only.
-     *       <li>Use {@link WeightedKeys} for weighted keys with score multipliers.
-     *     </ul>
-     *
-     * @return Command Response - The resulting sorted set from the union.
-     */
-    public T zunion(@NonNull KeysOrWeightedKeys keysOrWeightedKeys) {
-        ArgsArray commandArgs = buildArgs(keysOrWeightedKeys.toArgs());
+    public T zunion(@NonNull KeyArray keys) {
+        ArgsArray commandArgs = buildArgs(keys.toArgs());
         protobufTransaction.addCommands(buildCommand(ZUnion, commandArgs));
         return getThis();
     }
@@ -2518,6 +2492,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the union of members and their scores from sorted sets specified by the given <code>
      * keysOrWeightedKeys</code>.
      *
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
      *     <ul>
@@ -2547,6 +2522,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * To perform a <code>zunion</code> operation while specifying aggregation settings, use {@link
      * #zunionWithScores(KeysOrWeightedKeys, Aggregate)}.
      *
+     * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zunion/">redis.io</a> for more details.
      * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
      *     <ul>
@@ -2566,47 +2542,16 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
 
     /**
      * Returns the intersection of members from sorted sets specified by the given <code>
-     * keysOrWeightedKeys</code>.<br>
-     * To perform a <code>zinter</code> operation while specifying aggregation settings, use {@link
-     * #zinter(KeysOrWeightedKeys, Aggregate)}.<br>
+     * keys</code>.<br>
      * To get the elements with their scores, see {@link #zinterWithScores}.
      *
      * @since Redis 6.2 and above.
      * @see <a href="https://redis.io/commands/zinter/">redis.io</a> for more details.
-     * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
-     *     <ul>
-     *       <li>Use {@link KeyArray} for keys only.
-     *       <li>Use {@link WeightedKeys} for weighted keys with score multipliers.
-     *     </ul>
-     *
+     * @param keys The keys of the sorted sets.
      * @return Command Response - The resulting sorted set from the intersection.
      */
-    public T zinter(@NonNull KeysOrWeightedKeys keysOrWeightedKeys) {
-        ArgsArray commandArgs = buildArgs(keysOrWeightedKeys.toArgs());
-        protobufTransaction.addCommands(buildCommand(ZInter, commandArgs));
-        return getThis();
-    }
-
-    /**
-     * Returns the intersection of members from sorted sets specified by the given <code>
-     * keysOrWeightedKeys</code>. To get the elements with their scores, see {@link
-     * #zinterWithScores}.
-     *
-     * @since Redis 6.2 and above.
-     * @see <a href="https://redis.io/commands/zinter/">redis.io</a> for more details.
-     * @param keysOrWeightedKeys The keys of the sorted sets with possible formats:
-     *     <ul>
-     *       <li>Use {@link KeyArray} for keys intersection.
-     *       <li>Use {@link WeightedKeys} for weighted keys with score multipliers.
-     *     </ul>
-     *
-     * @param aggregate Specifies the aggregation strategy to apply when combining the scores of
-     *     elements.
-     * @return Command Response - The resulting sorted set from the intersection.
-     */
-    public T zinter(@NonNull KeysOrWeightedKeys keysOrWeightedKeys, @NonNull Aggregate aggregate) {
-        ArgsArray commandArgs =
-                buildArgs(concatenateArrays(keysOrWeightedKeys.toArgs(), aggregate.toArgs()));
+    public T zinter(@NonNull KeyArray keys) {
+        ArgsArray commandArgs = buildArgs(keys.toArgs());
         protobufTransaction.addCommands(buildCommand(ZInter, commandArgs));
         return getThis();
     }

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -3424,34 +3424,6 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
-    public void zunion_with_options_returns_success() {
-        // setup
-        List<Pair<String, Double>> keysWeights = new ArrayList<>();
-        keysWeights.add(Pair.of("key1", 10.0));
-        keysWeights.add(Pair.of("key2", 20.0));
-        WeightedKeys weightedKeys = new WeightedKeys(keysWeights);
-        Aggregate aggregate = Aggregate.MIN;
-        String[] arguments = concatenateArrays(weightedKeys.toArgs(), aggregate.toArgs());
-        String[] value = new String[] {"elem1", "elem2"};
-
-        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
-        testResponse.complete(value);
-
-        // match on protobuf request
-        when(commandManager.<String[]>submitNewCommand(eq(ZUnion), eq(arguments), any()))
-                .thenReturn(testResponse);
-
-        // exercise
-        CompletableFuture<String[]> response = service.zunion(weightedKeys, aggregate);
-        String[] payload = response.get();
-
-        // verify
-        assertEquals(testResponse, response);
-        assertEquals(value, payload);
-    }
-
-    @SneakyThrows
-    @Test
     public void zunionWithScores_returns_success() {
         // setup
         String[] keys = new String[] {"key1", "key2"};
@@ -3524,34 +3496,6 @@ public class RedisClientTest {
 
         // exercise
         CompletableFuture<String[]> response = service.zinter(keyArray);
-        String[] payload = response.get();
-
-        // verify
-        assertEquals(testResponse, response);
-        assertEquals(value, payload);
-    }
-
-    @SneakyThrows
-    @Test
-    public void zinter_with_aggregation_returns_success() {
-        // setup
-        List<Pair<String, Double>> keysWeights = new ArrayList<>();
-        keysWeights.add(Pair.of("key1", 10.0));
-        keysWeights.add(Pair.of("key2", 20.0));
-        WeightedKeys weightedKeys = new WeightedKeys(keysWeights);
-        Aggregate aggregate = Aggregate.MIN;
-        String[] arguments = concatenateArrays(weightedKeys.toArgs(), aggregate.toArgs());
-        String[] value = new String[] {"elem1", "elem2"};
-
-        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
-        testResponse.complete(value);
-
-        // match on protobuf request
-        when(commandManager.<String[]>submitNewCommand(eq(ZInter), eq(arguments), any()))
-                .thenReturn(testResponse);
-
-        // exercise
-        CompletableFuture<String[]> response = service.zinter(weightedKeys, aggregate);
         String[] payload = response.get();
 
         // verify

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -618,20 +618,6 @@ public class TransactionTests {
                                 AGGREGATE_REDIS_API,
                                 Aggregate.MAX.toString())));
 
-        transaction.zunion(new WeightedKeys(weightedKeys), Aggregate.MAX);
-        results.add(
-                Pair.of(
-                        ZUnion,
-                        buildArgs(
-                                "2",
-                                "key1",
-                                "key2",
-                                WEIGHTS_REDIS_API,
-                                "10.0",
-                                "20.0",
-                                AGGREGATE_REDIS_API,
-                                Aggregate.MAX.toString())));
-
         transaction.zunionWithScores(new WeightedKeys(weightedKeys), Aggregate.MAX);
         results.add(
                 Pair.of(
@@ -657,20 +643,6 @@ public class TransactionTests {
 
         transaction.zinterWithScores(new KeyArray(new String[] {"key1", "key2"}));
         results.add(Pair.of(ZInter, buildArgs("2", "key1", "key2", WITH_SCORES_REDIS_API)));
-
-        transaction.zinter(new WeightedKeys(weightedKeys), Aggregate.MAX);
-        results.add(
-                Pair.of(
-                        ZInter,
-                        buildArgs(
-                                "2",
-                                "key1",
-                                "key2",
-                                WEIGHTS_REDIS_API,
-                                "10.0",
-                                "20.0",
-                                AGGREGATE_REDIS_API,
-                                Aggregate.MAX.toString())));
 
         transaction.zinterWithScores(new WeightedKeys(weightedKeys), Aggregate.MAX);
         results.add(

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -2031,6 +2031,8 @@ public class SharedCommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     public void zdiff(BaseClient client) {
+        assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("6.2.0"), "This feature added in redis 6.2.0");
+
         String key1 = "{testKey}:1-" + UUID.randomUUID();
         String key2 = "{testKey}:2-" + UUID.randomUUID();
         String key3 = "{testKey}:3-" + UUID.randomUUID();
@@ -2100,6 +2102,8 @@ public class SharedCommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     public void zdiffstore(BaseClient client) {
+        assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("6.2.0"), "This feature added in redis 6.2.0");
+
         String key1 = "{testKey}:1-" + UUID.randomUUID();
         String key2 = "{testKey}:2-" + UUID.randomUUID();
         String key3 = "{testKey}:3-" + UUID.randomUUID();
@@ -2577,6 +2581,8 @@ public class SharedCommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     public void zunion(BaseClient client) {
+        assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("6.2.0"), "This feature added in redis 6.2.0");
+
         String key1 = "{testKey}:1-" + UUID.randomUUID();
         String key2 = "{testKey}:2-" + UUID.randomUUID();
         String key3 = "{testKey}:3-" + UUID.randomUUID();
@@ -2595,33 +2601,21 @@ public class SharedCommandTests {
                 client.zunionWithScores(new KeyArray(new String[] {key1, key2})).get());
 
         // Union results are aggregated by the max score of elements
-        assertArrayEquals(
-                new String[] {"one", "three", "two"},
-                client.zunion(new KeyArray(new String[] {key1, key2}), Aggregate.MAX).get());
         assertEquals(
                 Map.of("one", 1.0, "three", 3.0, "two", 3.5),
                 client.zunionWithScores(new KeyArray(new String[] {key1, key2}), Aggregate.MAX).get());
 
         // Union results are aggregated by the min score of elements
-        assertArrayEquals(
-                new String[] {"one", "two", "three"},
-                client.zunion(new KeyArray(new String[] {key1, key2}), Aggregate.MIN).get());
         assertEquals(
                 Map.of("one", 1.0, "two", 2.0, "three", 3.0),
                 client.zunionWithScores(new KeyArray(new String[] {key1, key2}), Aggregate.MIN).get());
 
         // Union results are aggregated by the sum of the scores of elements
-        assertArrayEquals(
-                new String[] {"one", "three", "two"},
-                client.zunion(new KeyArray(new String[] {key1, key2}), Aggregate.SUM).get());
         assertEquals(
                 Map.of("one", 1.0, "three", 3.0, "two", 5.5),
                 client.zunionWithScores(new KeyArray(new String[] {key1, key2}), Aggregate.SUM).get());
 
         // Scores are multiplied by 2.0 for key1 and key2 during aggregation.
-        assertArrayEquals(
-                new String[] {"one", "three", "two"},
-                client.zunion(new WeightedKeys(List.of(Pair.of(key1, 2.0), Pair.of(key2, 2.0)))).get());
         assertEquals(
                 Map.of("one", 2.0, "three", 6.0, "two", 11.0),
                 client
@@ -2630,12 +2624,6 @@ public class SharedCommandTests {
 
         // Union results are aggregated by the minimum score, with scores for key1 multiplied by 1.0 and
         // for key2 by -2.0.
-        assertArrayEquals(
-                new String[] {"two", "three", "one"},
-                client
-                        .zunion(
-                                new WeightedKeys(List.of(Pair.of(key1, 1.0), Pair.of(key2, -2.0))), Aggregate.MIN)
-                        .get());
         assertEquals(
                 Map.of("two", -7.0, "three", -6.0, "one", 1.0),
                 client
@@ -2663,6 +2651,8 @@ public class SharedCommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     public void zinter(BaseClient client) {
+        assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("6.2.0"), "This feature added in redis 6.2.0");
+
         String key1 = "{testKey}:1-" + UUID.randomUUID();
         String key2 = "{testKey}:2-" + UUID.randomUUID();
         String key3 = "{testKey}:3-" + UUID.randomUUID();
@@ -2679,33 +2669,21 @@ public class SharedCommandTests {
                 Map.of("two", 5.5), client.zinterWithScores(new KeyArray(new String[] {key1, key2})).get());
 
         // Intersection results are aggregated by the max score of elements
-        assertArrayEquals(
-                new String[] {"two"},
-                client.zinter(new KeyArray(new String[] {key1, key2}), Aggregate.MAX).get());
         assertEquals(
                 Map.of("two", 3.5),
                 client.zinterWithScores(new KeyArray(new String[] {key1, key2}), Aggregate.MAX).get());
 
         // Intersection results are aggregated by the min score of elements
-        assertArrayEquals(
-                new String[] {"two"},
-                client.zinter(new KeyArray(new String[] {key1, key2}), Aggregate.MIN).get());
         assertEquals(
                 Map.of("two", 2.0),
                 client.zinterWithScores(new KeyArray(new String[] {key1, key2}), Aggregate.MIN).get());
 
         // Intersection results are aggregated by the sum of the scores of elements
-        assertArrayEquals(
-                new String[] {"two"},
-                client.zinter(new KeyArray(new String[] {key1, key2}), Aggregate.SUM).get());
         assertEquals(
                 Map.of("two", 5.5),
                 client.zinterWithScores(new KeyArray(new String[] {key1, key2}), Aggregate.SUM).get());
 
         // Scores are multiplied by 2.0 for key1 and key2 during aggregation.
-        assertArrayEquals(
-                new String[] {"two"},
-                client.zinter(new WeightedKeys(List.of(Pair.of(key1, 2.0), Pair.of(key2, 2.0)))).get());
         assertEquals(
                 Map.of("two", 11.0),
                 client
@@ -2714,12 +2692,6 @@ public class SharedCommandTests {
 
         // Intersection results are aggregated by the minimum score,
         // with scores for key1 multiplied by 1.0 and for key2 by -2.0.
-        assertArrayEquals(
-                new String[] {"two"},
-                client
-                        .zinter(
-                                new WeightedKeys(List.of(Pair.of(key1, 1.0), Pair.of(key2, -2.0))), Aggregate.MIN)
-                        .get());
         assertEquals(
                 Map.of("two", -7.0),
                 client
@@ -2738,7 +2710,8 @@ public class SharedCommandTests {
         assertInstanceOf(RequestException.class, executionException.getCause());
         executionException =
                 assertThrows(
-                        ExecutionException.class, () -> client.zinter(new WeightedKeys(List.of())).get());
+                        ExecutionException.class,
+                        () -> client.zinterWithScores(new WeightedKeys(List.of())).get());
         assertInstanceOf(RequestException.class, executionException.getCause());
 
         // Key exists, but it is not a set

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -485,6 +485,7 @@ public class TransactionTestUtilities {
         if (REDIS_VERSION.isGreaterThanOrEqualTo("6.2.0")) {
             transaction
                     .zadd(zSetKey5, Map.of("one", 1.0, "two", 2.0))
+                    // zSetKey6 is empty
                     .zdiffstore(zSetKey6, new String[] {zSetKey6, zSetKey6})
                     .zdiff(new String[] {zSetKey5, zSetKey6})
                     .zdiffWithScores(new String[] {zSetKey5, zSetKey6})
@@ -534,7 +535,7 @@ public class TransactionTestUtilities {
                     0L, // zremrangebyscore(zSetKey1, new ScoreBoundary(5), InfScoreBound.POSITIVE_INFINITY)
                     2L, // zadd(zSetKey2, Map.of("one", 1.0, "two", 2.0))
                     new Object[] {zSetKey2, "two", 2.0}, // bzpopmax(new String[] { zsetKey2 }, .1)
-                    "one", // .zrandmember(zSetKey2)
+                    "one", // zrandmember(zSetKey2)
                     new String[] {"one"}, // .zrandmemberWithCount(zSetKey2, 1)
                     new Object[][] {{"one", 1.0}}, // .zrandmemberWithCountWithScores(zSetKey2, 1);
                     new Object[] {zSetKey2, "one", 1.0}, // bzpopmin(new String[] { zsetKey2 }, .1)
@@ -548,14 +549,11 @@ public class TransactionTestUtilities {
                                 2L, // zadd(zSetKey5, Map.of("one", 1.0, "two", 2.0))
                                 0L, // zdiffstore(zSetKey6, new String[] {zSetKey6, zSetKey6})
                                 new String[] {"one", "two"}, // zdiff(new String[] {zSetKey5, zSetKey6})
-                                Map.of(
-                                        "one", 1.0, "two", 2.0), // zdiffWithScores(new String[] {zSetKey5, zSetKey6})
+                                Map.of("one", 1.0, "two", 2.0), // zdiffWithScores({zSetKey5, zSetKey6})
                                 2L, // zunionstore(zSetKey5, new KeyArray(new String[] {zSetKey5, zSetKey6}))
                                 new String[] {"one", "two"}, // zunion(new KeyArray({zSetKey5, zSetKey6}))
-                                Map.of("one", 1.0, "two", 2.0), // zunionWithScores(KeyArray({zSetKey5, zSetKey6}));
-                                Map.of(
-                                        "one", 1.0, "two",
-                                        2.0), // zunionWithScores(KeyArray({zSetKey5, zSetKey6}), MAX)
+                                Map.of("one", 1.0, "two", 2.0), // zunionWithScores({zSetKey5, zSetKey6})
+                                Map.of("one", 1.0, "two", 2.0), // zunionWithScores({zSetKey5, zSetKey6}, MAX)
                                 0L, // zinterstore(zSetKey6, new String[] {zSetKey5, zSetKey6})
                                 new String[0], // zinter(new KeyArray({zSetKey5, zSetKey6}))
                                 Map.of(), // zinterWithScores(new KeyArray({zSetKey5, zSetKey6}))

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -449,6 +449,9 @@ public class TransactionTestUtilities {
         String zSetKey1 = "{ZSetKey}-1-" + UUID.randomUUID();
         String zSetKey2 = "{ZSetKey}-2-" + UUID.randomUUID();
         String zSetKey3 = "{ZSetKey}-3-" + UUID.randomUUID();
+        String zSetKey4 = "{ZSetKey}-4-" + UUID.randomUUID();
+        String zSetKey5 = "{ZSetKey}-4-" + UUID.randomUUID();
+        String zSetKey6 = "{ZSetKey}-5-" + UUID.randomUUID();
 
         transaction
                 .zadd(zSetKey1, Map.of("one", 1.0, "two", 2.0, "three", 3.0))
@@ -471,38 +474,41 @@ public class TransactionTestUtilities {
                 .zremrangebyrank(zSetKey1, 5, 10)
                 .zremrangebylex(zSetKey1, new LexBoundary("j"), InfLexBound.POSITIVE_INFINITY)
                 .zremrangebyscore(zSetKey1, new ScoreBoundary(5), InfScoreBound.POSITIVE_INFINITY)
-                .zdiffstore(zSetKey1, new String[] {zSetKey1, zSetKey1})
                 .zadd(zSetKey2, Map.of("one", 1.0, "two", 2.0))
-                .zdiff(new String[] {zSetKey2, zSetKey1})
-                .zdiffWithScores(new String[] {zSetKey2, zSetKey1})
-                .zunionstore(zSetKey2, new KeyArray(new String[] {zSetKey2, zSetKey1}))
-                .zunion(new KeyArray(new String[] {zSetKey2, zSetKey1}))
-                .zunion(new KeyArray(new String[] {zSetKey2, zSetKey1}), Aggregate.MAX)
-                .zunionWithScores(new KeyArray(new String[] {zSetKey2, zSetKey1}))
-                .zunionWithScores(new KeyArray(new String[] {zSetKey2, zSetKey1}), Aggregate.MAX)
-                .zinterstore(zSetKey1, new KeyArray(new String[] {zSetKey2, zSetKey1}))
-                .zinter(new KeyArray(new String[] {zSetKey2, zSetKey1}))
-                .zinter(new KeyArray(new String[] {zSetKey2, zSetKey1}), Aggregate.MAX)
-                .zinterWithScores(new KeyArray(new String[] {zSetKey2, zSetKey1}))
-                .zinterWithScores(new KeyArray(new String[] {zSetKey2, zSetKey1}), Aggregate.MAX)
                 .bzpopmax(new String[] {zSetKey2}, .1)
                 .zrandmember(zSetKey2)
                 .zrandmemberWithCount(zSetKey2, 1)
                 .zrandmemberWithCountWithScores(zSetKey2, 1)
-                .bzpopmin(new String[] {zSetKey2}, .1)
-                // zSetKey2 is now empty
-                .zadd(zSetKey2, Map.of("a", 1., "b", 2., "c", 3., "d", 4.));
+                .bzpopmin(new String[] {zSetKey2}, .1);
+        // zSetKey2 is now empty
+
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("6.2.0")) {
+            transaction
+                    .zadd(zSetKey5, Map.of("one", 1.0, "two", 2.0))
+                    .zdiffstore(zSetKey6, new String[] {zSetKey6, zSetKey6})
+                    .zdiff(new String[] {zSetKey5, zSetKey6})
+                    .zdiffWithScores(new String[] {zSetKey5, zSetKey6})
+                    .zunionstore(zSetKey5, new KeyArray(new String[] {zSetKey5, zSetKey6}))
+                    .zunion(new KeyArray(new String[] {zSetKey5, zSetKey6}))
+                    .zunionWithScores(new KeyArray(new String[] {zSetKey5, zSetKey6}))
+                    .zunionWithScores(new KeyArray(new String[] {zSetKey5, zSetKey6}), Aggregate.MAX)
+                    .zinterstore(zSetKey6, new KeyArray(new String[] {zSetKey5, zSetKey6}))
+                    .zinter(new KeyArray(new String[] {zSetKey5, zSetKey6}))
+                    .zinterWithScores(new KeyArray(new String[] {zSetKey5, zSetKey6}))
+                    .zinterWithScores(new KeyArray(new String[] {zSetKey5, zSetKey6}), Aggregate.MAX);
+        }
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             transaction
                     .zadd(zSetKey3, Map.of("a", 1., "b", 2., "c", 3., "d", 4., "e", 5., "f", 6., "g", 7.))
+                    .zadd(zSetKey4, Map.of("a", 1., "b", 2., "c", 3., "d", 4.))
                     .zmpop(new String[] {zSetKey3}, MAX)
                     .zmpop(new String[] {zSetKey3}, MIN, 2)
                     .bzmpop(new String[] {zSetKey3}, MAX, .1)
                     .bzmpop(new String[] {zSetKey3}, MIN, .1, 2)
                     .zadd(zSetKey3, Map.of("a", 1., "b", 2., "c", 3., "d", 4., "e", 5., "f", 6., "g", 7.))
-                    .zintercard(new String[] {zSetKey2, zSetKey3})
-                    .zintercard(new String[] {zSetKey2, zSetKey3}, 2);
+                    .zintercard(new String[] {zSetKey4, zSetKey3})
+                    .zintercard(new String[] {zSetKey4, zSetKey3}, 2);
         }
 
         var expectedResults =
@@ -526,41 +532,52 @@ public class TransactionTestUtilities {
                     0L, // zremrangebyrank(zSetKey1, 5, 10)
                     0L, // zremrangebylex(zSetKey1, new LexBoundary("j"), InfLexBound.POSITIVE_INFINITY)
                     0L, // zremrangebyscore(zSetKey1, new ScoreBoundary(5), InfScoreBound.POSITIVE_INFINITY)
-                    0L, // zdiffstore(zSetKey1, new String[] {zSetKey1, zSetKey1})
                     2L, // zadd(zSetKey2, Map.of("one", 1.0, "two", 2.0))
-                    new String[] {"one", "two"}, // zdiff(new String[] {zSetKey2, zSetKey1})
-                    Map.of("one", 1.0, "two", 2.0), // zdiffWithScores(new String[] {zSetKey2, zSetKey1})
-                    2L, // zunionstore(zSetKey2, new KeyArray(new String[] {zSetKey2, zSetKey1}))
-                    new String[] {"one", "two"}, // zunion(new KeyArray({zSetKey2, zSetKey1}))
-                    new String[] {"one", "two"}, // zunion(new KeyArray({zSetKey2, zSetKey1}), Aggregate.MAX);
-                    Map.of("one", 1.0, "two", 2.0), // zunionWithScores(KeyArray({zSetKey2, zSetKey1}));
-                    Map.of("one", 1.0, "two", 2.0), // zunionWithScores(KeyArray({zSetKey2, zSetKey1}), MAX)
-                    0L, // zinterstore(zSetKey1, new String[] {zSetKey2, zSetKey1})
-                    new String[0], // zinter(new KeyArray({zSetKey2, zSetKey1}))
-                    new String[0], // zinter(new KeyArray({zSetKey2, zSetKey1}), Aggregate.MAX)
-                    Map.of(), // zinterWithScores(new KeyArray({zSetKey2, zSetKey1}))
-                    Map.of(), // zinterWithScores(new KeyArray({zSetKey2, zSetKey1}), Aggregate.MAX)
                     new Object[] {zSetKey2, "two", 2.0}, // bzpopmax(new String[] { zsetKey2 }, .1)
                     "one", // .zrandmember(zSetKey2)
                     new String[] {"one"}, // .zrandmemberWithCount(zSetKey2, 1)
                     new Object[][] {{"one", 1.0}}, // .zrandmemberWithCountWithScores(zSetKey2, 1);
                     new Object[] {zSetKey2, "one", 1.0}, // bzpopmin(new String[] { zsetKey2 }, .1)
-                    4L, // zadd(zSetKey2, Map.of("a", 1., "b", 2., "c", 3., "d", 4.))
                 };
 
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("6.2.0")) {
+            expectedResults =
+                    concatenateArrays(
+                            expectedResults,
+                            new Object[] {
+                                2L, // zadd(zSetKey5, Map.of("one", 1.0, "two", 2.0))
+                                0L, // zdiffstore(zSetKey6, new String[] {zSetKey6, zSetKey6})
+                                new String[] {"one", "two"}, // zdiff(new String[] {zSetKey5, zSetKey6})
+                                Map.of(
+                                        "one", 1.0, "two", 2.0), // zdiffWithScores(new String[] {zSetKey5, zSetKey6})
+                                2L, // zunionstore(zSetKey5, new KeyArray(new String[] {zSetKey5, zSetKey6}))
+                                new String[] {"one", "two"}, // zunion(new KeyArray({zSetKey5, zSetKey6}))
+                                Map.of("one", 1.0, "two", 2.0), // zunionWithScores(KeyArray({zSetKey5, zSetKey6}));
+                                Map.of(
+                                        "one", 1.0, "two",
+                                        2.0), // zunionWithScores(KeyArray({zSetKey5, zSetKey6}), MAX)
+                                0L, // zinterstore(zSetKey6, new String[] {zSetKey5, zSetKey6})
+                                new String[0], // zinter(new KeyArray({zSetKey5, zSetKey6}))
+                                Map.of(), // zinterWithScores(new KeyArray({zSetKey5, zSetKey6}))
+                                Map.of(), // zinterWithScores(new KeyArray({zSetKey5, zSetKey6}), Aggregate.MAX)
+                            });
+        }
+
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
-            return concatenateArrays(
-                    expectedResults,
-                    new Object[] {
-                        7L, // zadd(zSetKey3, "a", 1., "b", 2., "c", 3., "d", 4., "e", 5., "f", 6., "g", 7.)
-                        new Object[] {zSetKey3, Map.of("g", 7.)}, // zmpop(zSetKey3, MAX)
-                        new Object[] {zSetKey3, Map.of("a", 1., "b", 2.)}, // zmpop(zSetKey3, MIN, 2)
-                        new Object[] {zSetKey3, Map.of("f", 6.)}, // bzmpop(zSetKey3, MAX, .1)
-                        new Object[] {zSetKey3, Map.of("c", 3., "d", 4.)}, // bzmpop(zSetKey3, MIN, .1, 2)
-                        6L, // zadd(zSetKey3, "a", 1., "b", 2., "c", 3., "d", 4., "e", 5., "f", 6., "g", 7.)
-                        4L, // zintercard(new String[] {zSetKey2, zSetKey3})
-                        2L, // zintercard(new String[] {zSetKey2, zSetKey3}, 2)
-                    });
+            expectedResults =
+                    concatenateArrays(
+                            expectedResults,
+                            new Object[] {
+                                7L, // zadd(zSetKey3, "a", 1., "b", 2., "c", 3., "d", 4., "e", 5., "f", 6., "g", 7.)
+                                4L, // zadd(zSetKey4, Map.of("a", 1., "b", 2., "c", 3., "d", 4.))
+                                new Object[] {zSetKey3, Map.of("g", 7.)}, // zmpop(zSetKey3, MAX)
+                                new Object[] {zSetKey3, Map.of("a", 1., "b", 2.)}, // zmpop(zSetKey3, MIN, 2)
+                                new Object[] {zSetKey3, Map.of("f", 6.)}, // bzmpop(zSetKey3, MAX, .1)
+                                new Object[] {zSetKey3, Map.of("c", 3., "d", 4.)}, // bzmpop(zSetKey3, MIN, .1, 2)
+                                6L, // zadd(zSetKey3, "a", 1., "b", 2., "c", 3., "d", 4., "e", 5., "f", 6., "g", 7.)
+                                4L, // zintercard(new String[] {zSetKey4, zSetKey3})
+                                2L, // zintercard(new String[] {zSetKey4, zSetKey3}, 2)
+                            });
         }
         return expectedResults;
     }


### PR DESCRIPTION
- Update `ZUNION`
  - Change `String[] zunion(KeysOrWeightedKeys)` -> `String[] zunion(KeyArray)`
  - Remove `String[] zunion(KeysOrWeightedKeys, Aggregate)`, because it is useless (`Aggregate` is noop)
- Update `ZINTER`
  - Change `String[] zinter(KeysOrWeightedKeys)` -> `String[] zunion(KeyArray)`
  - Remove `String[] zinter(KeysOrWeightedKeys, Aggregate)`, because it is useless (`Aggregate` is noop)
- Add `@since` to `ZINTER`, `ZUNION` and `ZDIFF`
- Update UT for `ZINTER`, `ZUNION`
- Update command IT `ZINTER`, `ZUNION` and `ZDIFF` to check version and match new signatures
- Update transaction IT the same manner