### PR TITLE
Node: change object command names to follow camel-case

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -2525,11 +2525,11 @@ export class BaseClient {
      *     Otherwise, returns None.
      * @example
      * ```typescript
-     * const result = await client.object_encoding("my_hash");
+     * const result = await client.objectEncoding("my_hash");
      * console.log(result); // Output: "listpack"
      * ```
      */
-    public object_encoding(key: string): Promise<string | null> {
+    public objectEncoding(key: string): Promise<string | null> {
         return this.createWritePromise(createObjectEncoding(key));
     }
 
@@ -2542,11 +2542,11 @@ export class BaseClient {
      *            stored at `key` as a `number`. Otherwise, returns `null`.
      * @example
      * ```typescript
-     * const result = await client.object_freq("my_hash");
+     * const result = await client.objectFreq("my_hash");
      * console.log(result); // Output: 2 - The logarithmic access frequency counter of "my_hash".
      * ```
      */
-    public object_freq(key: string): Promise<number | null> {
+    public objectFreq(key: string): Promise<number | null> {
         return this.createWritePromise(createObjectFreq(key));
     }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1460,7 +1460,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - If `key` exists, returns the internal encoding of the object stored at `key` as a string.
      *     Otherwise, returns None.
      */
-    public object_encoding(key: string): T {
+    public objectEncoding(key: string): T {
         return this.addAndReturn(createObjectEncoding(key));
     }
 
@@ -1472,7 +1472,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - If `key` exists, returns the logarithmic access frequency counter of
      *     the object stored at `key` as a `number`. Otherwise, returns `null`.
      */
-    public object_freq(key: string): T {
+    public objectFreq(key: string): T {
         return this.addAndReturn(createObjectFreq(key));
     }
 }

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -198,7 +198,7 @@ describe("RedisClient", () => {
                     [maxmemoryPolicyKey]: "allkeys-lfu",
                 });
                 transaction.set(key, "foo");
-                transaction.object_freq(key);
+                transaction.objectFreq(key);
 
                 const response = await client.exec(transaction);
                 expect(response).not.toBeNull();

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -343,7 +343,7 @@ describe("RedisClusterClient", () => {
                     [maxmemoryPolicyKey]: "allkeys-lfu",
                 });
                 transaction.set(key, "foo");
-                transaction.object_freq(key);
+                transaction.objectFreq(key);
 
                 const response = await client.exec(transaction);
                 expect(response).not.toBeNull();

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -3054,7 +3054,7 @@ export function runBaseTests<Context>(config: {
                 const versionLessThan72 =
                     await checkIfServerVersionLessThan("7.2.0");
 
-                expect(await client.object_encoding(non_existing_key)).toEqual(
+                expect(await client.objectEncoding(non_existing_key)).toEqual(
                     null,
                 );
 
@@ -3064,24 +3064,24 @@ export function runBaseTests<Context>(config: {
                         "a really loooooooooooooooooooooooooooooooooooooooong value",
                     ),
                 ).toEqual("OK");
-                expect(await client.object_encoding(string_key)).toEqual("raw");
+                expect(await client.objectEncoding(string_key)).toEqual("raw");
 
                 expect(await client.set(string_key, "2")).toEqual("OK");
-                expect(await client.object_encoding(string_key)).toEqual("int");
+                expect(await client.objectEncoding(string_key)).toEqual("int");
 
                 expect(await client.set(string_key, "value")).toEqual("OK");
-                expect(await client.object_encoding(string_key)).toEqual(
+                expect(await client.objectEncoding(string_key)).toEqual(
                     "embstr",
                 );
 
                 expect(await client.lpush(list_key, ["1"])).toEqual(1);
 
                 if (versionLessThan7) {
-                    expect(await client.object_encoding(list_key)).toEqual(
+                    expect(await client.objectEncoding(list_key)).toEqual(
                         "quicklist",
                     );
                 } else {
-                    expect(await client.object_encoding(list_key)).toEqual(
+                    expect(await client.objectEncoding(list_key)).toEqual(
                         "listpack",
                     );
                 }
@@ -3093,12 +3093,12 @@ export function runBaseTests<Context>(config: {
                     ).toEqual(1);
                 }
 
-                expect(await client.object_encoding(hashtable_key)).toEqual(
+                expect(await client.objectEncoding(hashtable_key)).toEqual(
                     "hashtable",
                 );
 
                 expect(await client.sadd(intset_key, ["1"])).toEqual(1);
-                expect(await client.object_encoding(intset_key)).toEqual(
+                expect(await client.objectEncoding(intset_key)).toEqual(
                     "intset",
                 );
 
@@ -3106,11 +3106,11 @@ export function runBaseTests<Context>(config: {
 
                 if (versionLessThan72) {
                     expect(
-                        await client.object_encoding(set_listpack_key),
+                        await client.objectEncoding(set_listpack_key),
                     ).toEqual("hashtable");
                 } else {
                     expect(
-                        await client.object_encoding(set_listpack_key),
+                        await client.objectEncoding(set_listpack_key),
                     ).toEqual("listpack");
                 }
 
@@ -3123,9 +3123,9 @@ export function runBaseTests<Context>(config: {
                     ).toEqual(1);
                 }
 
-                expect(
-                    await client.object_encoding(hash_hashtable_key),
-                ).toEqual("hashtable");
+                expect(await client.objectEncoding(hash_hashtable_key)).toEqual(
+                    "hashtable",
+                );
 
                 expect(
                     await client.hset(hash_listpack_key, { "1": "2" }),
@@ -3133,11 +3133,11 @@ export function runBaseTests<Context>(config: {
 
                 if (versionLessThan7) {
                     expect(
-                        await client.object_encoding(hash_listpack_key),
+                        await client.objectEncoding(hash_listpack_key),
                     ).toEqual("ziplist");
                 } else {
                     expect(
-                        await client.object_encoding(hash_listpack_key),
+                        await client.objectEncoding(hash_listpack_key),
                     ).toEqual("listpack");
                 }
 
@@ -3148,7 +3148,7 @@ export function runBaseTests<Context>(config: {
                     ).toEqual(1);
                 }
 
-                expect(await client.object_encoding(skiplist_key)).toEqual(
+                expect(await client.objectEncoding(skiplist_key)).toEqual(
                     "skiplist",
                 );
 
@@ -3158,18 +3158,18 @@ export function runBaseTests<Context>(config: {
 
                 if (versionLessThan7) {
                     expect(
-                        await client.object_encoding(zset_listpack_key),
+                        await client.objectEncoding(zset_listpack_key),
                     ).toEqual("ziplist");
                 } else {
                     expect(
-                        await client.object_encoding(zset_listpack_key),
+                        await client.objectEncoding(zset_listpack_key),
                     ).toEqual("listpack");
                 }
 
                 expect(
                     await client.xadd(stream_key, [["field", "value"]]),
                 ).not.toBeNull();
-                expect(await client.object_encoding(stream_key)).toEqual(
+                expect(await client.objectEncoding(stream_key)).toEqual(
                     "stream",
                 );
             }, protocol);
@@ -3193,13 +3193,13 @@ export function runBaseTests<Context>(config: {
                             [maxmemoryPolicyKey]: "allkeys-lfu",
                         }),
                     ).toEqual("OK");
-                    expect(await client.object_freq(nonExistingKey)).toEqual(
+                    expect(await client.objectFreq(nonExistingKey)).toEqual(
                         null,
                     );
                     expect(await client.set(key, "foobar")).toEqual("OK");
-                    expect(
-                        await client.object_freq(key),
-                    ).toBeGreaterThanOrEqual(0);
+                    expect(await client.objectFreq(key)).toBeGreaterThanOrEqual(
+                        0,
+                    );
                 } finally {
                     expect(
                         await client.configSet({

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -237,7 +237,7 @@ export async function transactionTest(
     const args: ReturnType[] = [];
     baseTransaction.set(key1, "bar");
     args.push("OK");
-    baseTransaction.object_encoding(key1);
+    baseTransaction.objectEncoding(key1);
     args.push("embstr");
     baseTransaction.type(key1);
     args.push("string");


### PR DESCRIPTION
Javascript follows camel-case for its variable naming convention. This PR updates the object command functions to follow camel-case.