### PR TITLE
Separated unwatch to have different docs for standalone

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -117,7 +117,6 @@ import static redis_request.RedisRequestOuterClass.RequestType.Strlen;
 import static redis_request.RedisRequestOuterClass.RequestType.TTL;
 import static redis_request.RedisRequestOuterClass.RequestType.Touch;
 import static redis_request.RedisRequestOuterClass.RequestType.Type;
-import static redis_request.RedisRequestOuterClass.RequestType.UnWatch;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.Watch;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
@@ -1906,10 +1905,5 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<String> watch(@NonNull String[] keys) {
         return commandManager.submitNewCommand(Watch, keys, this::handleStringResponse);
-    }
-
-    @Override
-    public CompletableFuture<String> unwatch() {
-        return commandManager.submitNewCommand(UnWatch, new String[0], this::handleStringResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -31,11 +31,13 @@ import static redis_request.RedisRequestOuterClass.RequestType.Move;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.Select;
 import static redis_request.RedisRequestOuterClass.RequestType.Time;
+import static redis_request.RedisRequestOuterClass.RequestType.UnWatch;
 
 import glide.api.commands.ConnectionManagementCommands;
 import glide.api.commands.GenericCommands;
 import glide.api.commands.ScriptingAndFunctionsCommands;
 import glide.api.commands.ServerManagementCommands;
+import glide.api.commands.TransactionsCommands;
 import glide.api.models.Transaction;
 import glide.api.models.commands.FlushMode;
 import glide.api.models.commands.InfoOptions;
@@ -56,7 +58,8 @@ public class RedisClient extends BaseClient
         implements GenericCommands,
                 ServerManagementCommands,
                 ConnectionManagementCommands,
-                ScriptingAndFunctionsCommands {
+                ScriptingAndFunctionsCommands,
+                TransactionsCommands {
 
     protected RedisClient(ConnectionManager connectionManager, CommandManager commandManager) {
         super(connectionManager, commandManager);
@@ -296,5 +299,10 @@ public class RedisClient extends BaseClient
                 FunctionStats,
                 new String[0],
                 response -> handleFunctionStatsResponse(handleMapResponse(response)));
+    }
+
+    @Override
+    public CompletableFuture<String> unwatch() {
+        return commandManager.submitNewCommand(UnWatch, new String[0], this::handleStringResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -660,4 +660,9 @@ public class RedisClusterClient extends BaseClient
         return commandManager.submitNewCommand(
                 UnWatch, new String[0], route, this::handleStringResponse);
     }
+
+    @Override
+    public CompletableFuture<String> unwatch() {
+        return commandManager.submitNewCommand(UnWatch, new String[0], this::handleStringResponse);
+    }
 }

--- a/java/client/src/main/java/glide/api/commands/TransactionsBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/TransactionsBaseCommands.java
@@ -34,18 +34,4 @@ public interface TransactionsBaseCommands {
      * }</pre>
      */
     CompletableFuture<String> watch(String[] keys);
-
-    /**
-     * Flushes all the previously watched keys for a transaction. Executing a transaction will
-     * automatically flush all previously watched keys.
-     *
-     * @see <a href="https://redis.io/docs/latest/commands/unwatch/">redis.io</a> for details.
-     * @return <code>OK</code>.
-     * @example
-     *     <pre>{@code
-     * assert client.watch(new String[] {"sampleKey"}).get().equals("OK");
-     * assert client.unwatch().get().equals("OK"); // Flushes "sampleKey" from watched keys.
-     * }</pre>
-     */
-    CompletableFuture<String> unwatch();
 }

--- a/java/client/src/main/java/glide/api/commands/TransactionsClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/TransactionsClusterCommands.java
@@ -12,8 +12,8 @@ import java.util.concurrent.CompletableFuture;
 public interface TransactionsClusterCommands {
     /**
      * Flushes all the previously watched keys for a transaction. Executing a transaction will
-     * automatically flush all previously watched keys. The command will be routed to all primary
-     * nodes.
+     * automatically flush all previously watched keys.<br>
+     * The command will be routed to all primary nodes.
      *
      * @see <a href="https://redis.io/docs/latest/commands/unwatch/">redis.io</a> for details.
      * @return <code>OK</code>.

--- a/java/client/src/main/java/glide/api/commands/TransactionsCommands.java
+++ b/java/client/src/main/java/glide/api/commands/TransactionsCommands.java
@@ -1,0 +1,25 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Supports commands for the "Transactions Commands" group for standalone clients.
+ *
+ * @see <a href="https://redis.io/commands/?group=transactions">Transactions Commands</a>
+ */
+public interface TransactionsCommands {
+    /**
+     * Flushes all the previously watched keys for a transaction. Executing a transaction will
+     * automatically flush all previously watched keys.
+     *
+     * @see <a href="https://redis.io/docs/latest/commands/unwatch/">redis.io</a> for details.
+     * @return <code>OK</code>.
+     * @example
+     *     <pre>{@code
+     * assert client.watch(new String[] {"sampleKey"}).get().equals("OK");
+     * assert client.unwatch().get().equals("OK"); // Flushes "sampleKey" from watched keys.
+     * }</pre>
+     */
+    CompletableFuture<String> unwatch();
+}


### PR DESCRIPTION
Comments in https://github.com/aws/glide-for-redis/pull/1539 weren't fully addressed. This PR makes `unwatch` consistent with other keyless commands where the apis are duplicated for cluster and standalone clients for documentation purposes.