### PR TITLE
Add Python cmd GetEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 * Node: Added OBJECT REFCOUNT command ([#1568](https://github.com/aws/glide-for-redis/pull/1568))
 * Python: Added SETBIT command ([#1571](https://github.com/aws/glide-for-redis/pull/1571))
 * Python: Added GETBIT command ([#1575](https://github.com/aws/glide-for-redis/pull/1575))
+* Python: Added GETEX command ([#0000](https://github.com/aws/glide-for-redis/pull/TODOLINK))
+*
 * Python: Added BITCOUNT command ([#1592](https://github.com/aws/glide-for-redis/pull/1592))
 
 ### Breaking Changes

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -222,6 +222,7 @@ enum RequestType {
     GeoSearch = 182;
     Watch = 183;
     UnWatch = 184;
+    GetEx = 190;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -192,6 +192,7 @@ pub enum RequestType {
     GeoSearch = 182,
     Watch = 183,
     UnWatch = 184,
+    GetEx = 190,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -387,6 +388,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::GeoSearch => RequestType::GeoSearch,
             ProtobufRequestType::Watch => RequestType::Watch,
             ProtobufRequestType::UnWatch => RequestType::UnWatch,
+            ProtobufRequestType::GetEx => RequestType::GetEx,
         }
     }
 }
@@ -578,6 +580,7 @@ impl RequestType {
             RequestType::GeoSearch => Some(cmd("GEOSEARCH")),
             RequestType::Watch => Some(cmd("WATCH")),
             RequestType::UnWatch => Some(cmd("UNWATCH")),
+            RequestType::GetEx => Some(cmd("GETEX")),
         }
     }
 }

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -5,8 +5,10 @@ from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
+    ExpiryGetEx,
     ExpirySet,
     ExpiryType,
+    ExpiryTypeGetEx,
     InfoSection,
     InsertPosition,
     StreamAddOptions,

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -71,6 +71,23 @@ class ExpiryType(Enum):
     KEEP_TTL = 4, Type[None]  # Equivalent to `KEEPTTL` in the Redis API
 
 
+class ExpiryTypeGetEx(Enum):
+    """SET option: The type of the expiry.
+    - EX - Set the specified expire time, in seconds. Equivalent to `EX` in the Redis API.
+    - PX - Set the specified expire time, in milliseconds. Equivalent to `PX` in the Redis API.
+    - UNIX_SEC - Set the specified Unix time at which the key will expire, in seconds. Equivalent to `EXAT` in the Redis API.
+    - UNIX_MILLSEC - Set the specified Unix time at which the key will expire, in milliseconds. Equivalent to `PXAT` in the
+        Redis API.
+    - PERSIST - Remove the time to live associated with the key. Equivalent to `PERSIST` in the Redis API.
+    """
+
+    SEC = 0, Union[int, timedelta]  # Equivalent to `EX` in the Redis API
+    MILLSEC = 1, Union[int, timedelta]  # Equivalent to `PX` in the Redis API
+    UNIX_SEC = 2, Union[int, datetime]  # Equivalent to `EXAT` in the Redis API
+    UNIX_MILLSEC = 3, Union[int, datetime]  # Equivalent to `PXAT` in the Redis API
+    PERSIST = 4, Type[None]  # Equivalent to `PERSIST` in the Redis API
+
+
 class InfoSection(Enum):
     """
     INFO option: a specific section of information:
@@ -318,6 +335,61 @@ class ExpirySet:
                 value = int(value.timestamp() * 1000)
         elif self.expiry_type == ExpiryType.KEEP_TTL:
             self.cmd_arg = "KEEPTTL"
+        self.value = str(value) if value else None
+
+    def get_cmd_args(self) -> List[str]:
+        return [self.cmd_arg] if self.value is None else [self.cmd_arg, self.value]
+
+
+class ExpiryGetEx:
+    """GetEx option: Represents the expiry type and value to be executed with "GetEx" command."""
+
+    def __init__(
+        self,
+        expiry_type: ExpiryTypeGetEx,
+        value: Optional[Union[int, datetime, timedelta]],
+    ) -> None:
+        """
+        Args:
+            - expiry_type (ExpiryType): The expiry type.
+            - value (Optional[Union[int, datetime, timedelta]]): The value of the expiration type. The type of expiration
+                determines the type of expiration value:
+                - SEC: Union[int, timedelta]
+                - MILLSEC: Union[int, timedelta]
+                - UNIX_SEC: Union[int, datetime]
+                - UNIX_MILLSEC: Union[int, datetime]
+                - PERSIST: Type[None]
+        """
+        self.set_expiry_type_and_value(expiry_type, value)
+
+    def set_expiry_type_and_value(
+        self,
+        expiry_type: ExpiryTypeGetEx,
+        value: Optional[Union[int, datetime, timedelta]],
+    ):
+        if not isinstance(value, get_args(expiry_type.value[1])):
+            raise ValueError(
+                f"The value of {expiry_type} should be of type {expiry_type.value[1]}"
+            )
+        self.expiry_type = expiry_type
+        if self.expiry_type == ExpiryTypeGetEx.SEC:
+            self.cmd_arg = "EX"
+            if isinstance(value, timedelta):
+                value = int(value.total_seconds())
+        elif self.expiry_type == ExpiryTypeGetEx.MILLSEC:
+            self.cmd_arg = "PX"
+            if isinstance(value, timedelta):
+                value = int(value.total_seconds() * 1000)
+        elif self.expiry_type == ExpiryTypeGetEx.UNIX_SEC:
+            self.cmd_arg = "EXAT"
+            if isinstance(value, datetime):
+                value = int(value.timestamp())
+        elif self.expiry_type == ExpiryTypeGetEx.UNIX_MILLSEC:
+            self.cmd_arg = "PXAT"
+            if isinstance(value, datetime):
+                value = int(value.timestamp() * 1000)
+        elif self.expiry_type == ExpiryTypeGetEx.PERSIST:
+            self.cmd_arg = "PERSIST"
         self.value = str(value) if value else None
 
     def get_cmd_args(self) -> List[str]:
@@ -4287,4 +4359,42 @@ class CoreCommands(Protocol):
         return cast(
             Optional[int],
             await self._execute_command(RequestType.ObjectRefCount, [key]),
+        )
+
+    async def getex(
+        self,
+        key: str,
+        expiry: Optional[ExpiryGetEx] = None,
+    ) -> Optional[str]:
+        """
+        Get the value of `key` and optionally set its expiration. GETEX is similar to GET, but is a write command with `ExpiryGetEx` options.
+        See https://valkey.io/commands/getex for more details.
+        Args:
+            key (str): The key to get.
+            expiry (Optional[ExpirySet], optional): set expiriation to the given key.
+                Equivalent to [`EX` | `PX` | `EXAT` | `PXAT` | `KEEPTTL`] in the Redis API. Defaults to None.
+        Returns:
+            Optional[str]:
+                If `key` exists, return the value stored at `key`
+                If 'key` does not exist, return 'None'
+        Since: Redis version 6.2.0.
+        Examples:
+            >>> await client.set("key", "value")
+                'OK'
+            >>> await client.getex("key")
+                'value'
+            >>> await client.getex("key", ExpiryGetEx(ExpiryTypeGetEx.SEC, 1))
+                'value`
+            >>> time.sleep(1)
+            >>> await client.getex("key")
+                'None'
+                :param key:
+                :param expiry:
+        """
+        args = [key]
+        if expiry is not None:
+            args.extend(expiry.get_cmd_args())
+        return cast(
+            Optional[str],
+            await self._execute_command(RequestType.GetEx, args),
         )

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -4367,7 +4367,7 @@ class CoreCommands(Protocol):
         expiry: Optional[ExpiryGetEx] = None,
     ) -> Optional[str]:
         """
-        Get the value of `key` and optionally set its expiration. `GETEX` is similar to `GET`, but is a write command with `ExpiryGetEx` options.
+        Get the value of `key` and optionally set its expiration. `GETEX` is similar to `GET`.
         See https://valkey.io/commands/getex for more details.
 
         Args:

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -72,7 +72,7 @@ class ExpiryType(Enum):
 
 
 class ExpiryTypeGetEx(Enum):
-    """SET option: The type of the expiry.
+    """GetEx option: The type of the expiry.
     - EX - Set the specified expire time, in seconds. Equivalent to `EX` in the Redis API.
     - PX - Set the specified expire time, in milliseconds. Equivalent to `PX` in the Redis API.
     - UNIX_SEC - Set the specified Unix time at which the key will expire, in seconds. Equivalent to `EXAT` in the Redis API.

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -4367,18 +4367,18 @@ class CoreCommands(Protocol):
         expiry: Optional[ExpiryGetEx] = None,
     ) -> Optional[str]:
         """
-        Get the value of `key` and optionally set its expiration. GETEX is similar to GET, but is a write command with `ExpiryGetEx` options.
+        Get the value of `key` and optionally set its expiration. `GETEX` is similar to `GET`, but is a write command with `ExpiryGetEx` options.
         See https://valkey.io/commands/getex for more details.
 
         Args:
             key (str): The key to get.
             expiry (Optional[ExpirySet], optional): set expiriation to the given key.
-                Equivalent to [`EX` | `PX` | `EXAT` | `PXAT` | `KEEPTTL`] in the Redis API. Defaults to None.
+                Equivalent to [`EX` | `PX` | `EXAT` | `PXAT` | `PERSIST`] in the Redis API.
 
         Returns:
             Optional[str]:
                 If `key` exists, return the value stored at `key`
-                If 'key` does not exist, return 'None'
+                If `key` does not exist, return `None`
 
         Examples:
             >>> await client.set("key", "value")

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -4369,27 +4369,29 @@ class CoreCommands(Protocol):
         """
         Get the value of `key` and optionally set its expiration. GETEX is similar to GET, but is a write command with `ExpiryGetEx` options.
         See https://valkey.io/commands/getex for more details.
+
         Args:
             key (str): The key to get.
             expiry (Optional[ExpirySet], optional): set expiriation to the given key.
                 Equivalent to [`EX` | `PX` | `EXAT` | `PXAT` | `KEEPTTL`] in the Redis API. Defaults to None.
+
         Returns:
             Optional[str]:
                 If `key` exists, return the value stored at `key`
                 If 'key` does not exist, return 'None'
-        Since: Redis version 6.2.0.
+
         Examples:
             >>> await client.set("key", "value")
                 'OK'
             >>> await client.getex("key")
                 'value'
             >>> await client.getex("key", ExpiryGetEx(ExpiryTypeGetEx.SEC, 1))
-                'value`
+                'value'
             >>> time.sleep(1)
             >>> await client.getex("key")
-                'None'
-                :param key:
-                :param expiry:
+                None
+
+        Since: Redis version 6.2.0.
         """
         args = [key]
         if expiry is not None:

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -8,6 +8,7 @@ from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
+    ExpiryGetEx,
     ExpirySet,
     GeospatialData,
     GeoUnit,
@@ -2973,6 +2974,27 @@ class BaseTransaction:
                 Otherwise, returns None.
         """
         return self.append_command(RequestType.ObjectRefCount, [key])
+
+    def getex(
+        self: TTransaction, key: str, expiry: Optional[ExpiryGetEx] = None
+    ) -> TTransaction:
+        """
+        Get the value of `key` and optionally set its expiration. GETEX is similar to GET, but is a write command with `ExpiryGetEx` options.
+        See https://valkey.io/commands/getex for more details.
+        Args:
+            key (str): The key to get.
+            expiry (Optional[ExpirySet], optional): set expiriation to the given key.
+                Equivalent to [`EX` | `PX` | `EXAT` | `PXAT` | `KEEPTTL`] in the Redis API. Defaults to None.
+        Command Response:
+            Optional[str]:
+                If `key` exists, return the value stored at `key`
+                If 'key` does not exist, return 'None'
+        Since: Redis version 6.2.0.
+        """
+        args = [key]
+        if expiry is not None:
+            args.extend(expiry.get_cmd_args())
+        return self.append_command(RequestType.GetEx, args)
 
 
 class Transaction(BaseTransaction):

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2985,7 +2985,7 @@ class BaseTransaction:
         Args:
             key (str): The key to get.
             expiry (Optional[ExpirySet], optional): set expiriation to the given key.
-                Equivalent to [`EX` | `PX` | `EXAT` | `PXAT` | `KEEPTTL`] in the Redis API. Defaults to None.
+                Equivalent to [`EX` | `PX` | `EXAT` | `PXAT` | `PERSIST`] in the Redis API.
 
         Command Response:
             Optional[str]:

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2979,7 +2979,7 @@ class BaseTransaction:
         self: TTransaction, key: str, expiry: Optional[ExpiryGetEx] = None
     ) -> TTransaction:
         """
-        Get the value of `key` and optionally set its expiration. GETEX is similar to GET, but is a write command with `ExpiryGetEx` options.
+        Get the value of `key` and optionally set its expiration. GETEX is similar to GET.
         See https://valkey.io/commands/getex for more details.
 
         Args:

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2981,14 +2981,17 @@ class BaseTransaction:
         """
         Get the value of `key` and optionally set its expiration. GETEX is similar to GET, but is a write command with `ExpiryGetEx` options.
         See https://valkey.io/commands/getex for more details.
+
         Args:
             key (str): The key to get.
             expiry (Optional[ExpirySet], optional): set expiriation to the given key.
                 Equivalent to [`EX` | `PX` | `EXAT` | `PXAT` | `KEEPTTL`] in the Redis API. Defaults to None.
+
         Command Response:
             Optional[str]:
                 If `key` exists, return the value stored at `key`
                 If 'key` does not exist, return 'None'
+
         Since: Redis version 6.2.0.
         """
         args = [key]

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -4559,27 +4559,26 @@ class TestCommands:
         assert await redis_client.set(key1, value) == OK
         assert await redis_client.getex(non_existing_key) is None
         assert await redis_client.getex(key1) == value
+        assert await redis_client.ttl(key1) == -1
 
         # setting expiration timer
         assert (
             await redis_client.getex(key1, ExpiryGetEx(ExpiryTypeGetEx.MILLSEC, 50))
             == value
         )
-        time.sleep(0.1)
-        assert await redis_client.get(key1) is None
+        assert await redis_client.ttl(key1) != -1
 
         # setting and clearing expiration timer
         assert await redis_client.set(key1, value) == OK
         assert (
-            await redis_client.getex(key1, ExpiryGetEx(ExpiryTypeGetEx.MILLSEC, 100))
+            await redis_client.getex(key1, ExpiryGetEx(ExpiryTypeGetEx.SEC, 10))
             == value
         )
         assert (
             await redis_client.getex(key1, ExpiryGetEx(ExpiryTypeGetEx.PERSIST, None))
             == value
         )
-        time.sleep(0.1)
-        assert await redis_client.get(key1) == value
+        assert await redis_client.ttl(key1) == -1
 
 
 class TestMultiKeyCommandCrossSlot:

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -16,8 +16,10 @@ from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
+    ExpiryGetEx,
     ExpirySet,
     ExpiryType,
+    ExpiryTypeGetEx,
     InfBound,
     InfoSection,
     InsertPosition,
@@ -4543,6 +4545,42 @@ class TestCommands:
         refcount = await redis_client.object_refcount(string_key)
         assert refcount is not None and refcount >= 0
 
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_getex(self, redis_client: TRedisClient):
+        min_version = "6.2.0"
+        if await check_if_server_version_lt(redis_client, min_version):
+            return pytest.mark.skip(reason=f"Redis version required >= {min_version}")
+
+        key1 = get_random_string(10)
+        non_existing_key = get_random_string(10)
+        value = get_random_string(10)
+
+        assert await redis_client.set(key1, value) == OK
+        assert await redis_client.getex(non_existing_key) is None
+        assert await redis_client.getex(key1) == value
+
+        # setting expiration timer
+        assert (
+            await redis_client.getex(key1, ExpiryGetEx(ExpiryTypeGetEx.MILLSEC, 50))
+            == value
+        )
+        time.sleep(0.1)
+        assert await redis_client.get(key1) is None
+
+        # setting and clearing expiration timer
+        assert await redis_client.set(key1, value) == OK
+        assert (
+            await redis_client.getex(key1, ExpiryGetEx(ExpiryTypeGetEx.MILLSEC, 100))
+            == value
+        )
+        assert (
+            await redis_client.getex(key1, ExpiryGetEx(ExpiryTypeGetEx.PERSIST, None))
+            == value
+        )
+        time.sleep(0.1)
+        assert await redis_client.get(key1) == value
+
 
 class TestMultiKeyCommandCrossSlot:
     @pytest.mark.parametrize("cluster_mode", [True])
@@ -4647,6 +4685,44 @@ class TestCommandsUnitTests:
 
         exp_unix_millisec_datetime = ExpirySet(
             ExpiryType.UNIX_MILLSEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
+        )
+        assert exp_unix_millisec_datetime.get_cmd_args() == ["PXAT", "1682639759342"]
+
+    def test_get_expiry_cmd_args(self):
+        exp_sec = ExpiryGetEx(ExpiryTypeGetEx.SEC, 5)
+        assert exp_sec.get_cmd_args() == ["EX", "5"]
+
+        exp_sec_timedelta = ExpiryGetEx(ExpiryTypeGetEx.SEC, timedelta(seconds=5))
+        assert exp_sec_timedelta.get_cmd_args() == ["EX", "5"]
+
+        exp_millsec = ExpiryGetEx(ExpiryTypeGetEx.MILLSEC, 5)
+        assert exp_millsec.get_cmd_args() == ["PX", "5"]
+
+        exp_millsec_timedelta = ExpiryGetEx(
+            ExpiryTypeGetEx.MILLSEC, timedelta(seconds=5)
+        )
+        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
+
+        exp_millsec_timedelta = ExpiryGetEx(
+            ExpiryTypeGetEx.MILLSEC, timedelta(seconds=5)
+        )
+        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
+
+        exp_unix_sec = ExpiryGetEx(ExpiryTypeGetEx.UNIX_SEC, 1682575739)
+        assert exp_unix_sec.get_cmd_args() == ["EXAT", "1682575739"]
+
+        exp_unix_sec_datetime = ExpiryGetEx(
+            ExpiryTypeGetEx.UNIX_SEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
+        )
+        assert exp_unix_sec_datetime.get_cmd_args() == ["EXAT", "1682639759"]
+
+        exp_unix_millisec = ExpiryGetEx(ExpiryTypeGetEx.UNIX_MILLSEC, 1682586559964)
+        assert exp_unix_millisec.get_cmd_args() == ["PXAT", "1682586559964"]
+
+        exp_unix_millisec_datetime = ExpiryGetEx(
+            ExpiryTypeGetEx.UNIX_MILLSEC,
             datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
         )
         assert exp_unix_millisec_datetime.get_cmd_args() == ["PXAT", "1682639759342"]


### PR DESCRIPTION
- `SET` and `GetEx` takes a similar set of expiry metric inputs with 1 difference, is there a better way than creating a new set of enum/option class for getex's version? Adding to SET's enum will cause undesired behavior but this feels like a lot of duplicated code

update: Will priotize consistency in the client's behavior and avoid doing refactoring to `SET` for now, point above is tracked with an internal ticket [here](https://github.com/orgs/Bit-Quill/projects/5/views/1?filterQuery=-status%3A%22NEEDS+GROOMING%22+&pane=issue&itemId=67911212).