### PR TITLE
Java: Add the `XREADGROUP` command

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -1441,7 +1441,7 @@ public abstract class BaseClient
             @NonNull Map<String, String> keysAndIds,
             @NonNull String group,
             @NonNull String consumer,
-            StreamReadGroupOptions options) {
+            @NonNull StreamReadGroupOptions options) {
         String[] arguments = options.toArgs(group, consumer, keysAndIds);
         return commandManager.submitNewCommand(XReadGroup, arguments, this::handleXReadResponse);
     }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -128,6 +128,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XRead;
+import static redis_request.RedisRequestOuterClass.RequestType.XReadGroup;
 import static redis_request.RedisRequestOuterClass.RequestType.XRevRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.ZAdd;
@@ -194,6 +195,7 @@ import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange;
+import glide.api.models.commands.stream.StreamReadGroupOptions;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions;
 import glide.api.models.configuration.BaseClientConfiguration;
@@ -1426,6 +1428,22 @@ public abstract class BaseClient
             @NonNull String key, @NonNull String group, @NonNull String consumer) {
         return commandManager.submitNewCommand(
                 XGroupDelConsumer, new String[] {key, group, consumer}, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Map<String, String[][]>>> xreadgroup(
+            @NonNull Map<String, String> keysAndIds, @NonNull String group, @NonNull String consumer) {
+        return xreadgroup(keysAndIds, group, consumer, StreamReadGroupOptions.builder().build());
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Map<String, String[][]>>> xreadgroup(
+            @NonNull Map<String, String> keysAndIds,
+            @NonNull String group,
+            @NonNull String consumer,
+            StreamReadGroupOptions options) {
+        String[] arguments = options.toArgs(group, consumer, keysAndIds);
+        return commandManager.submitNewCommand(XReadGroup, arguments, this::handleXReadResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -69,7 +69,7 @@ public interface StreamBaseCommands {
      * @param keysAndIds A <code>Map</code> of keys and entry ids to read from. The <code>
      *     Map</code> is composed of a stream's key and the id of the entry after which the stream
      *     will be read.
-     * @return A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
+     * @return A <code>{@literal Map<String, Map<String, String[][]>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
      * @example
      *     <pre>{@code
@@ -96,7 +96,7 @@ public interface StreamBaseCommands {
      *     Map</code> is composed of a stream's key and the id of the entry after which the stream
      *     will be read.
      * @param options Options detailing how to read the stream {@link StreamReadOptions}.
-     * @return A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
+     * @return A <code>{@literal Map<String, Map<String, String[][]>>}</code> with stream
      *     keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
      * @example
      *     <pre>{@code
@@ -420,7 +420,7 @@ public interface StreamBaseCommands {
      *     will be read. Use the special id of <code>{@literal ">"}</code> to receive only new messages.
      * @param group The consumer group name.
      * @param consumer The newly created consumer.
-     * @return A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
+     * @return A <code>{@literal Map<String, Map<String, String[][]>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
      *      Returns null if the consumer group does not exist. Returns a Map with a value of null if the stream is empty.
      * @example
@@ -429,7 +429,7 @@ public interface StreamBaseCommands {
      * Map<String, String> xreadKeys = Map.of("myfield", "mydata");
      * String streamId = client.xadd("mystream", Map.of("myfield", "mydata"), StreamAddOptions.builder().id("1-0").build()).get();
      * assert client.xgroupCreate("mystream", "mygroup").get().equals("OK"); // create the consumer group "mygroup"
-     * Map<String, Map<String, String[][]>> streamReadResponse = client.xreadgroup("mygroup", "myconsumer", Map.of("mystream", ">")).get();
+     * Map<String, Map<String, String[][]>> streamReadResponse = client.xreadgroup(Map.of("mystream", ">"), "mygroup", "myconsumer").get();
      * // Returns "mystream": "1-0": {{"myfield", "mydata"}}
      * for (var keyEntry : streamReadResponse.entrySet()) {
      *     System.out.printf("Key: %s", keyEntry.getKey());
@@ -440,7 +440,7 @@ public interface StreamBaseCommands {
      *     }
      * }
      * assert client.xdel("mystream", "1-0").get() == 1L;
-     * client.xreadgroup("mygroup", "myconsumer", Map.of("mystream", "0")).get();
+     * client.xreadgroup(Map.of("mystream", "0"), "mygroup", "myconsumer").get();
      * // Returns "mystream": "1-0": null
      * assert streamReadResponse.get("mystream").get("1-0") == null;
      * </pre>
@@ -460,7 +460,7 @@ public interface StreamBaseCommands {
      * @param group The consumer group name.
      * @param consumer The newly created consumer.
      * @param options Options detailing how to read the stream {@link StreamReadGroupOptions}.
-     * @return A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
+     * @return A <code>{@literal Map<String, Map<String, String[][]>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
      *      Returns null if the consumer group does not exist. Returns a Map with a value of null if the stream is empty.
      * @example
@@ -469,8 +469,8 @@ public interface StreamBaseCommands {
      * Map<String, String> xreadKeys = Map.of("myfield", "mydata");
      * String streamId = client.xadd("mystream", Map.of("myfield", "mydata"), StreamAddOptions.builder().id("1-0").build()).get();
      * assert client.xgroupCreate("mystream", "mygroup").get().equals("OK"); // create the consumer group "mygroup"
-     * StreamReadGroupOptions op = StreamReadGroupOptions.builder().count(1).build(); // retrieves only a single message at a time
-     * Map<String, Map<String, String[][]>> streamReadResponse = client.xreadgroup("mygroup", "myconsumer", Map.of("mystream", ">"), op).get();
+     * StreamReadGroupOptions options = StreamReadGroupOptions.builder().count(1).build(); // retrieves only a single message at a time
+     * Map<String, Map<String, String[][]>> streamReadResponse = client.xreadgroup(Map.of("mystream", ">"), "mygroup", "myconsumer", options).get();
      * // Returns "mystream": "1-0": {{"myfield", "mydata"}}
      * for (var keyEntry : streamReadResponse.entrySet()) {
      *     System.out.printf("Key: %s", keyEntry.getKey());
@@ -481,7 +481,9 @@ public interface StreamBaseCommands {
      *     }
      * }
      * assert client.xdel("mystream", "1-0").get() == 1L;
-     * streamReadResponse = client.xreadgroup("mygroup", "myconsumer", Map.of("mystream", "0"), op).get();
+     * // read the first 10 items and acknowledge (ACK) them:
+     * StreamReadGroupOptions options = StreamReadGroupOptions.builder().count(10L).noack().build();
+     * streamReadResponse = client.xreadgroup(Map.of("mystream", "0"), "mygroup", "myconsumer", options).get();
      * // Returns "mystream": "1-0": null
      * assert streamReadResponse.get("mystream").get("1-0") == null;
      * </pre>

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -422,6 +422,7 @@ public interface StreamBaseCommands {
      * @param consumer The newly created consumer.
      * @return A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
+     *      Returns null if the consumer group does not exist. Returns a Map with a value of null if the stream is empty.
      * @example
      *     <pre>{@code
      * // create a new stream at "mystream", with stream id "1-0"
@@ -461,6 +462,7 @@ public interface StreamBaseCommands {
      * @param options Options detailing how to read the stream {@link StreamReadGroupOptions}.
      * @return A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
+     *      Returns null if the consumer group does not exist. Returns a Map with a value of null if the stream is empty.
      * @example
      *     <pre>{@code
      * // create a new stream at "mystream", with stream id "1-0"

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -2768,7 +2768,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param keysAndIds An array of <code>Pair</code>s of keys and entry ids to read from. A <code>
      *     pair</code> is composed of a stream's key and the id of the entry after which the stream
      *     will be read.
-     * @return Command Response - A <code>{@literal Map<String, Map<Object[][]>>}</code> with stream
+     * @return Command Response - A <code>{@literal Map<String, Map<String, String[][]>>}</code> with stream
      *     keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
      */
     public T xread(@NonNull Map<String, String> keysAndIds) {
@@ -2783,7 +2783,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     pair</code> is composed of a stream's key and the id of the entry after which the stream
      *     will be read.
      * @param options options detailing how to read the stream {@link StreamReadOptions}.
-     * @return Command Response - A <code>{@literal Map<String, Map<Object[][]>>}</code> with stream
+     * @return Command Response - A <code>{@literal Map<String, Map<String, String[][]>>}</code> with stream
      *     keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
      */
     public T xread(@NonNull Map<String, String> keysAndIds, @NonNull StreamReadOptions options) {
@@ -3057,14 +3057,15 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://valkey.io/commands/xreadgroup/">valkey.io</a> for details.
      * @param keysAndIds A <code>Map</code> of keys and entry ids to read from. The <code>
      *     Map</code> is composed of a stream's key and the id of the entry after which the stream
-     *     will be read. Use the special id of <code>{@literal ">"}</code> to receive only new messages.
+     *     will be read. Use the special id of <code>{@literal Map<String, Map<String, String[][]>>}</code> to receive only new messages.
      * @param group The consumer group name.
      * @param consumer The newly created consumer.
-     * @return Command Response - A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
+     * @return Command Response - A <code>{@literal Map<String, Map<String, Map<String[][]>>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
      *      Returns null if the consumer group does not exist. Returns a Map with a value of null if the stream is empty.
      */
-    public T xreadgroup(Map<String, String> keysAndIds, String group, String consumer) {
+    public T xreadgroup(
+            @NonNull Map<String, String> keysAndIds, @NonNull String group, @NonNull String consumer) {
         return xreadgroup(keysAndIds, group, consumer, StreamReadGroupOptions.builder().build());
     }
 
@@ -3076,19 +3077,19 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://valkey.io/commands/xreadgroup/">valkey.io</a> for details.
      * @param keysAndIds A <code>Map</code> of keys and entry ids to read from. The <code>
      *     Map</code> is composed of a stream's key and the id of the entry after which the stream
-     *     will be read. Use the special id of <code>{@literal ">"}</code> to receive only new messages.
+     *     will be read. Use the special id of <code>{@literal Map<String, Map<String, String[][]>>}</code> to receive only new messages.
      * @param group The consumer group name.
      * @param consumer The newly created consumer.
      * @param options Options detailing how to read the stream {@link StreamReadGroupOptions}.
-     * @return Command Response - A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
+     * @return Command Response - A <code>{@literal Map<String, Map<String, Map<String[][]>>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
      *      Returns null if the consumer group does not exist. Returns a Map with a value of null if the stream is empty.
      */
     public T xreadgroup(
-            Map<String, String> keysAndIds,
-            String group,
-            String consumer,
-            StreamReadGroupOptions options) {
+            @NonNull Map<String, String> keysAndIds,
+            @NonNull String group,
+            @NonNull String consumer,
+            @NonNull StreamReadGroupOptions options) {
         protobufTransaction.addCommands(
                 buildCommand(XReadGroup, buildArgs(options.toArgs(group, consumer, keysAndIds))));
         return getThis();

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -3062,6 +3062,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param consumer The newly created consumer.
      * @return Command Response - A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
+     *      Returns null if the consumer group does not exist. Returns a Map with a value of null if the stream is empty.
      */
     public T xreadgroup(Map<String, String> keysAndIds, String group, String consumer) {
         return xreadgroup(keysAndIds, group, consumer, StreamReadGroupOptions.builder().build());
@@ -3081,6 +3082,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param options Options detailing how to read the stream {@link StreamReadGroupOptions}.
      * @return Command Response - A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
      *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
+     *      Returns null if the consumer group does not exist. Returns a Map with a value of null if the stream is empty.
      */
     public T xreadgroup(
             Map<String, String> keysAndIds,

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -156,6 +156,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XRead;
+import static redis_request.RedisRequestOuterClass.RequestType.XReadGroup;
 import static redis_request.RedisRequestOuterClass.RequestType.XRevRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.ZAdd;
@@ -232,6 +233,7 @@ import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamAddOptions.StreamAddOptionsBuilder;
 import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange;
+import glide.api.models.commands.stream.StreamReadGroupOptions;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions;
 import glide.api.models.configuration.ReadFrom;
@@ -3044,6 +3046,49 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     public T xgroupDelConsumer(@NonNull String key, @NonNull String group, @NonNull String consumer) {
         protobufTransaction.addCommands(
                 buildCommand(XGroupDelConsumer, buildArgs(key, group, consumer)));
+        return getThis();
+    }
+
+    /**
+     * Reads entries from the given streams owned by a consumer group.
+     *
+     * @apiNote When in cluster mode, all keys in <code>keysAndIds</code> must map to the same hash
+     *     slot.
+     * @see <a href="https://valkey.io/commands/xreadgroup/">valkey.io</a> for details.
+     * @param keysAndIds A <code>Map</code> of keys and entry ids to read from. The <code>
+     *     Map</code> is composed of a stream's key and the id of the entry after which the stream
+     *     will be read. Use the special id of <code>{@literal ">"}</code> to receive only new messages.
+     * @param group The consumer group name.
+     * @param consumer The newly created consumer.
+     * @return Command Response - A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
+     *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
+     */
+    public T xreadgroup(Map<String, String> keysAndIds, String group, String consumer) {
+        return xreadgroup(keysAndIds, group, consumer, StreamReadGroupOptions.builder().build());
+    }
+
+    /**
+     * Reads entries from the given streams owned by a consumer group.
+     *
+     * @apiNote When in cluster mode, all keys in <code>keysAndIds</code> must map to the same hash
+     *     slot.
+     * @see <a href="https://valkey.io/commands/xreadgroup/">valkey.io</a> for details.
+     * @param keysAndIds A <code>Map</code> of keys and entry ids to read from. The <code>
+     *     Map</code> is composed of a stream's key and the id of the entry after which the stream
+     *     will be read. Use the special id of <code>{@literal ">"}</code> to receive only new messages.
+     * @param group The consumer group name.
+     * @param consumer The newly created consumer.
+     * @param options Options detailing how to read the stream {@link StreamReadGroupOptions}.
+     * @return Command Response - A <code>{@literal Map<String, Map<String[][]>>}</code> with stream
+     *      keys, to <code>Map</code> of stream-ids, to an array of pairings with format <code>[[field, entry], [field, entry], ...]<code>.
+     */
+    public T xreadgroup(
+            Map<String, String> keysAndIds,
+            String group,
+            String consumer,
+            StreamReadGroupOptions options) {
+        protobufTransaction.addCommands(
+                buildCommand(XReadGroup, buildArgs(options.toArgs(group, consumer, keysAndIds))));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/commands/stream/StreamReadGroupOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/stream/StreamReadGroupOptions.java
@@ -10,36 +10,34 @@ import java.util.stream.Collectors;
 import lombok.experimental.SuperBuilder;
 
 /**
- * Optional arguments for {@link StreamBaseCommands#xread(Map, StreamReadOptions)}
+ * Optional arguments for {@link StreamBaseCommands#xreadgroup(Map, String, String,
+ * StreamReadGroupOptions)}
  *
- * @see <a href="https://redis.io/commands/xread/">redis.io</a>
+ * @see <a href="https://valkey.io/commands/xreadgroup/">redis.io</a>
  */
 @SuperBuilder
-public class StreamReadOptions {
+public final class StreamReadGroupOptions extends StreamReadOptions {
 
-    public static final String READ_COUNT_REDIS_API = "COUNT";
-    public static final String READ_BLOCK_REDIS_API = "BLOCK";
-    public static final String READ_STREAMS_REDIS_API = "STREAMS";
+    public static final String READ_GROUP_REDIS_API = "GROUP";
+    public static final String READ_NOACK_REDIS_API = "NOACK";
 
     /**
-     * If set, the request will be blocked for the set amount of milliseconds or until the server has
-     * the required number of entries. Equivalent to <code>BLOCK</code> in the Redis API.
+     * If set, messages are not added to the Pending Entries List (PEL). This is equivalent to
+     * acknowledging the message when it is read.
      */
-    protected Long block;
+    private Boolean noack;
 
     /**
-     * The maximal number of elements requested. Equivalent to <code>COUNT</code> in the Redis API.
-     */
-    protected Long count;
-
-    /**
-     * Converts options and the key-to-id input for {@link StreamBaseCommands#xread(Map,
-     * StreamReadOptions)} into a String[].
+     * Converts options and the key-to-id input for {@link StreamBaseCommands#xreadgroup(Map, String,
+     * String, StreamReadGroupOptions)} into a String[].
      *
      * @return String[]
      */
-    public String[] toArgs(Map<String, String> streams) {
+    public String[] toArgs(String group, String consumer, Map<String, String> streams) {
         List<String> optionArgs = new ArrayList<>();
+        optionArgs.add(READ_GROUP_REDIS_API);
+        optionArgs.add(group);
+        optionArgs.add(consumer);
 
         if (this.count != null) {
             optionArgs.add(READ_COUNT_REDIS_API);
@@ -49,6 +47,10 @@ public class StreamReadOptions {
         if (this.block != null) {
             optionArgs.add(READ_BLOCK_REDIS_API);
             optionArgs.add(block.toString());
+        }
+
+        if (this.noack != null && this.noack) {
+            optionArgs.add(READ_NOACK_REDIS_API);
         }
 
         optionArgs.add(READ_STREAMS_REDIS_API);

--- a/java/client/src/main/java/glide/api/models/commands/stream/StreamReadGroupOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/stream/StreamReadGroupOptions.java
@@ -25,7 +25,16 @@ public final class StreamReadGroupOptions extends StreamReadOptions {
      * If set, messages are not added to the Pending Entries List (PEL). This is equivalent to
      * acknowledging the message when it is read.
      */
-    private Boolean noack;
+    private boolean noack;
+
+    public abstract static class StreamReadGroupOptionsBuilder<
+                    C extends StreamReadGroupOptions, B extends StreamReadGroupOptionsBuilder<C, B>>
+            extends StreamReadOptions.StreamReadOptionsBuilder<C, B> {
+        public B noack() {
+            this.noack = true;
+            return self();
+        }
+    }
 
     /**
      * Converts options and the key-to-id input for {@link StreamBaseCommands#xreadgroup(Map, String,
@@ -49,7 +58,7 @@ public final class StreamReadGroupOptions extends StreamReadOptions {
             optionArgs.add(block.toString());
         }
 
-        if (this.noack != null && this.noack) {
+        if (this.noack) {
             optionArgs.add(READ_NOACK_REDIS_API);
         }
 

--- a/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
+++ b/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
@@ -5,6 +5,7 @@ import glide.api.commands.GeospatialIndicesBaseCommands;
 import glide.api.models.commands.geospatial.GeospatialData;
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -128,7 +129,10 @@ public class ArrayTransformUtils {
             return null;
         }
         return mapOfArrays.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> castArrayofArrays(e.getValue(), clazz)));
+                .collect(
+                        HashMap::new,
+                        (m, e) -> m.put(e.getKey(), castArrayofArrays(e.getValue(), clazz)),
+                        HashMap::putAll);
     }
 
     /**

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -33,6 +33,8 @@ import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_RE
 import static glide.api.models.commands.stream.StreamRange.MAXIMUM_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.MINIMUM_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.RANGE_COUNT_REDIS_API;
+import static glide.api.models.commands.stream.StreamReadGroupOptions.READ_GROUP_REDIS_API;
+import static glide.api.models.commands.stream.StreamReadGroupOptions.READ_NOACK_REDIS_API;
 import static glide.api.models.commands.stream.StreamReadOptions.READ_BLOCK_REDIS_API;
 import static glide.api.models.commands.stream.StreamReadOptions.READ_COUNT_REDIS_API;
 import static glide.api.models.commands.stream.StreamReadOptions.READ_STREAMS_REDIS_API;
@@ -194,6 +196,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XRead;
+import static redis_request.RedisRequestOuterClass.RequestType.XReadGroup;
 import static redis_request.RedisRequestOuterClass.RequestType.XRevRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.ZAdd;
@@ -267,6 +270,7 @@ import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange;
 import glide.api.models.commands.stream.StreamRange.IdBound;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
+import glide.api.models.commands.stream.StreamReadGroupOptions;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions;
 import glide.api.models.commands.stream.StreamTrimOptions.MaxLen;
@@ -4508,6 +4512,103 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(result, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xreadgroup_multiple_keys() {
+        // setup
+        String keyOne = "one";
+        String streamIdOne = "id-one";
+        String keyTwo = "two";
+        String streamIdTwo = "id-two";
+        String groupName = "testGroup";
+        String consumerName = "consumerGroup";
+        String[][] fieldValues = {{"field", "value"}};
+        Map<String, Map<String, String[][]>> completedResult = new LinkedHashMap<>();
+        completedResult.put(keyOne, Map.of(streamIdOne, fieldValues));
+        completedResult.put(keyTwo, Map.of(streamIdTwo, fieldValues));
+        String[] arguments = {
+            READ_GROUP_REDIS_API,
+            groupName,
+            consumerName,
+            READ_STREAMS_REDIS_API,
+            keyOne,
+            keyTwo,
+            streamIdOne,
+            streamIdTwo
+        };
+
+        CompletableFuture<Map<String, Map<String, String[][]>>> testResponse =
+                new CompletableFuture<>();
+        testResponse.complete(completedResult);
+
+        // match on protobuf request
+        when(commandManager.<Map<String, Map<String, String[][]>>>submitNewCommand(
+                        eq(XReadGroup), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        Map<String, String> keysAndIds = new LinkedHashMap<>();
+        keysAndIds.put(keyOne, streamIdOne);
+        keysAndIds.put(keyTwo, streamIdTwo);
+        CompletableFuture<Map<String, Map<String, String[][]>>> response =
+                service.xreadgroup(keysAndIds, groupName, consumerName);
+        Map<String, Map<String, String[][]>> payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(completedResult, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xreadgroup_with_options() {
+        // setup
+        String keyOne = "one";
+        String streamIdOne = "id-one";
+        Long block = 2L;
+        Long count = 10L;
+        String groupName = "testGroup";
+        String consumerName = "consumerGroup";
+        String[][] fieldValues = {{"field", "value"}};
+        Map<String, Map<String, String[][]>> completedResult =
+                Map.of(keyOne, Map.of(streamIdOne, fieldValues));
+        String[] arguments = {
+            READ_GROUP_REDIS_API,
+            groupName,
+            consumerName,
+            READ_COUNT_REDIS_API,
+            count.toString(),
+            READ_BLOCK_REDIS_API,
+            block.toString(),
+            READ_NOACK_REDIS_API,
+            READ_STREAMS_REDIS_API,
+            keyOne,
+            streamIdOne
+        };
+
+        CompletableFuture<Map<String, Map<String, String[][]>>> testResponse =
+                new CompletableFuture<>();
+        testResponse.complete(completedResult);
+
+        // match on protobuf request
+        when(commandManager.<Map<String, Map<String, String[][]>>>submitNewCommand(
+                        eq(XReadGroup), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<String, Map<String, String[][]>>> response =
+                service.xreadgroup(
+                        Map.of(keyOne, streamIdOne),
+                        groupName,
+                        consumerName,
+                        StreamReadGroupOptions.builder().block(block).count(count).noack(true).build());
+        Map<String, Map<String, String[][]>> payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(completedResult, payload);
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -4603,7 +4603,7 @@ public class RedisClientTest {
                         Map.of(keyOne, streamIdOne),
                         groupName,
                         consumerName,
-                        StreamReadGroupOptions.builder().block(block).count(count).noack(true).build());
+                        StreamReadGroupOptions.builder().block(block).count(count).noack().build());
         Map<String, Map<String, String[][]>> payload = response.get();
 
         // verify

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -800,7 +800,7 @@ public class TransactionTests {
                 Map.of("key", "id"),
                 "group",
                 "consumer",
-                StreamReadGroupOptions.builder().block(1L).count(2L).noack(true).build());
+                StreamReadGroupOptions.builder().block(1L).count(2L).noack().build());
         results.add(
                 Pair.of(
                         XReadGroup,

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -29,6 +29,8 @@ import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_RE
 import static glide.api.models.commands.stream.StreamRange.MAXIMUM_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.MINIMUM_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.RANGE_COUNT_REDIS_API;
+import static glide.api.models.commands.stream.StreamReadGroupOptions.READ_GROUP_REDIS_API;
+import static glide.api.models.commands.stream.StreamReadGroupOptions.READ_NOACK_REDIS_API;
 import static glide.api.models.commands.stream.StreamReadOptions.READ_BLOCK_REDIS_API;
 import static glide.api.models.commands.stream.StreamReadOptions.READ_COUNT_REDIS_API;
 import static glide.api.models.commands.stream.StreamReadOptions.READ_STREAMS_REDIS_API;
@@ -170,6 +172,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XRead;
+import static redis_request.RedisRequestOuterClass.RequestType.XReadGroup;
 import static redis_request.RedisRequestOuterClass.RequestType.XRevRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.ZAdd;
@@ -234,6 +237,7 @@ import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
+import glide.api.models.commands.stream.StreamReadGroupOptions;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions.MinId;
 import java.util.ArrayList;
@@ -784,6 +788,34 @@ public class TransactionTests {
 
         transaction.xgroupDelConsumer("key", "group", "consumer");
         results.add(Pair.of(XGroupDelConsumer, buildArgs("key", "group", "consumer")));
+
+        transaction.xreadgroup(Map.of("key", "id"), "group", "consumer");
+        results.add(
+                Pair.of(
+                        XReadGroup,
+                        buildArgs(
+                                READ_GROUP_REDIS_API, "group", "consumer", READ_STREAMS_REDIS_API, "key", "id")));
+
+        transaction.xreadgroup(
+                Map.of("key", "id"),
+                "group",
+                "consumer",
+                StreamReadGroupOptions.builder().block(1L).count(2L).noack(true).build());
+        results.add(
+                Pair.of(
+                        XReadGroup,
+                        buildArgs(
+                                READ_GROUP_REDIS_API,
+                                "group",
+                                "consumer",
+                                READ_COUNT_REDIS_API,
+                                "2",
+                                READ_BLOCK_REDIS_API,
+                                "1",
+                                READ_NOACK_REDIS_API,
+                                READ_STREAMS_REDIS_API,
+                                "key",
+                                "id")));
 
         transaction.time();
         results.add(Pair.of(Time, buildArgs()));

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3519,7 +3519,13 @@ public class SharedCommandTests {
 
         // read the entire stream for the consumer and mark messages as pending
         var result_1 = client.xreadgroup(Map.of(key, ">"), groupName, consumerName).get();
-        assertEquals(2, result_1.get(key).size());
+        assertDeepEquals(
+                Map.of(
+                        key,
+                        Map.of(
+                                streamid_1, new String[][] {{"field1", "value1"}},
+                                streamid_2, new String[][] {{"field2", "value2"}})),
+                result_1);
 
         // delete one of the streams
         assertEquals(1L, client.xdel(key, new String[] {streamid_1}).get());
@@ -3642,7 +3648,7 @@ public class SharedCommandTests {
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
 
-        // Key exists, but it is not a stream
+        // First key exists, but it is not a stream
         assertEquals(OK, client.set(nonStreamKey, "bar").get());
         ExecutionException executionException =
                 assertThrows(
@@ -3656,6 +3662,7 @@ public class SharedCommandTests {
                                         .get());
         assertInstanceOf(RequestException.class, executionException.getCause());
 
+        // Second key exists, but it is not a stream
         executionException =
                 assertThrows(
                         ExecutionException.class,

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3531,6 +3531,62 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
+    public void xgroupCreateConsumer_xgroupDelConsumer(BaseClient client) {
+        String key = UUID.randomUUID().toString();
+        String stringKey = UUID.randomUUID().toString();
+        String groupName = "group" + UUID.randomUUID();
+        String zeroStreamId = "0";
+        String consumerName = "consumer" + UUID.randomUUID();
+
+        // create group and consumer for the group
+        assertEquals(
+                OK,
+                client
+                        .xgroupCreate(
+                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                        .get());
+        assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
+
+        // create consumer for group that does not exist results in a NOGROUP request error
+        ExecutionException executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.xgroupCreateConsumer(key, "not_a_group", consumerName).get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+        assertTrue(executionException.getMessage().contains("NOGROUP"));
+
+        // create consumer for group again
+        assertFalse(client.xgroupCreateConsumer(key, groupName, consumerName).get());
+
+        // Deletes a consumer that is not created yet returns 0
+        assertEquals(0L, client.xgroupDelConsumer(key, groupName, "not_a_consumer").get());
+
+        // String streamid_1 = client.xadd(key, Map.of("field1", "value1")).get();
+        // assertNotNull(streamid_1);
+        // String streamid_2 = client.xadd(key, Map.of("field2", "value2")).get();
+        // assertNotNull(streamid_2);
+
+        // TODO use XREADGROUP to mark pending messages for the consumer so that we get non-zero return
+        assertEquals(0L, client.xgroupDelConsumer(key, groupName, consumerName).get());
+
+        // key is a string and cannot be created as a stream
+        assertEquals(OK, client.set(stringKey, "not_a_stream").get());
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.xgroupCreateConsumer(stringKey, groupName, consumerName).get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.xgroupDelConsumer(stringKey, groupName, consumerName).get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
     public void zrandmember(BaseClient client) {
         String key1 = UUID.randomUUID().toString();
         String key2 = UUID.randomUUID().toString();

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -69,6 +69,7 @@ import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange.IdBound;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
+import glide.api.models.commands.stream.StreamReadGroupOptions;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions.MaxLen;
 import glide.api.models.commands.stream.StreamTrimOptions.MinId;
@@ -3480,7 +3481,7 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
-    public void xgroupCreateConsumer_xgroupDelConsumer(BaseClient client) {
+    public void xgroupCreateConsumer_xreadgroup_xgroupDelConsumer(BaseClient client) {
         String key = UUID.randomUUID().toString();
         String stringKey = UUID.randomUUID().toString();
         String groupName = "group" + UUID.randomUUID();
@@ -3510,8 +3511,37 @@ public class SharedCommandTests {
         // Deletes a consumer that is not created yet returns 0
         assertEquals(0L, client.xgroupDelConsumer(key, groupName, "not_a_consumer").get());
 
-        // TODO use XREADGROUP to mark pending messages for the consumer so that we get non-zero return
-        assertEquals(0L, client.xgroupDelConsumer(key, groupName, consumerName).get());
+        // Add two stream entries
+        String streamid_1 = client.xadd(key, Map.of("field1", "value1")).get();
+        assertNotNull(streamid_1);
+        String streamid_2 = client.xadd(key, Map.of("field2", "value2")).get();
+        assertNotNull(streamid_2);
+
+        // read the entire stream for the consumer and mark messages as pending
+        var result_1 = client.xreadgroup(Map.of(key, ">"), groupName, consumerName).get();
+        assertEquals(2, result_1.get(key).size());
+
+        // delete one of the streams
+        assertEquals(1L, client.xdel(key, new String[] {streamid_1}).get());
+
+        // now xreadgroup yeilds one empty stream and one non-empty stream
+        var result_2 = client.xreadgroup(Map.of(key, "0"), groupName, consumerName).get();
+        assertEquals(2, result_2.get(key).size());
+        assertNull(result_2.get(key).get(streamid_1));
+        assertArrayEquals(new String[][] {{"field2", "value2"}}, result_2.get(key).get(streamid_2));
+
+        String streamid_3 = client.xadd(key, Map.of("field3", "value3")).get();
+        assertNotNull(streamid_3);
+
+        // Delete the consumer group and expect 2 pending messages
+        assertEquals(2L, client.xgroupDelConsumer(key, groupName, consumerName).get());
+
+        // Consume the last message with the previously deleted consumer (creates the consumer anew)
+        var result_3 = client.xreadgroup(Map.of(key, ">"), groupName, consumerName).get();
+        assertEquals(1, result_3.get(key).size());
+
+        // Delete the consumer group and expect the pending message
+        assertEquals(1L, client.xgroupDelConsumer(key, groupName, consumerName).get());
 
         // key is a string and cannot be created as a stream
         assertEquals(OK, client.set(stringKey, "not_a_stream").get());
@@ -3582,6 +3612,102 @@ public class SharedCommandTests {
                         ExecutionException.class,
                         () -> client.xgroupDelConsumer(stringKey, groupName, consumerName).get());
         assertInstanceOf(RequestException.class, executionException.getCause());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void xreadgroup_return_failures(BaseClient client) {
+        String key = "{key}:1" + UUID.randomUUID();
+        String nonStreamKey = "{key}:3" + UUID.randomUUID();
+        String field1 = "f1_";
+
+        // setup first entries in streams key1 and key2
+        Map<String, String> timestamp_1_1_map = new LinkedHashMap<>();
+        timestamp_1_1_map.put(field1, field1 + "1");
+        String timestamp_1_1 =
+            client.xadd(key, timestamp_1_1_map, StreamAddOptions.builder().id("1-1").build()).get();
+        assertNotNull(timestamp_1_1);
+
+        String groupName = "group" + UUID.randomUUID();
+        String zeroStreamId = "0";
+        String consumerName = "consumer" + UUID.randomUUID();
+
+        // create group and consumer for the group
+        assertEquals(
+            OK,
+            client
+                .xgroupCreate(
+                    key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                .get());
+        assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
+
+        // Key exists, but it is not a stream
+        assertEquals(OK, client.set(nonStreamKey, "bar").get());
+        ExecutionException executionException =
+            assertThrows(
+                ExecutionException.class,
+                () ->
+                    client
+                        .xreadgroup(
+                            Map.of(nonStreamKey, timestamp_1_1, key, timestamp_1_1),
+                            groupName,
+                            consumerName)
+                        .get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+
+        executionException =
+            assertThrows(
+                ExecutionException.class,
+                () ->
+                    client
+                        .xreadgroup(
+                            Map.of(key, timestamp_1_1, nonStreamKey, timestamp_1_1),
+                            groupName,
+                            consumerName)
+                        .get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+
+        try (var testClient =
+                 client instanceof RedisClient
+                     ? RedisClient.CreateClient(commonClientConfig().build()).get()
+                     : RedisClusterClient.CreateClient(commonClusterClientConfig().build()).get()) {
+            String timeoutKey = "{key}:2" + UUID.randomUUID();
+            String timeoutGroupName = "group" + UUID.randomUUID();
+            String timeoutConsumerName = "consumer" + UUID.randomUUID();
+
+            assertEquals(
+                OK,
+                client
+                    .xgroupCreate(
+                        timeoutKey, timeoutGroupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                    .get());
+            assertTrue(client.xgroupCreateConsumer(timeoutKey, timeoutGroupName, timeoutConsumerName).get());
+
+            // ensure that command doesn't time out even if timeout > request timeout
+            long oneSecondInMS = 1000L;
+            assertNull(
+                testClient
+                    .xreadgroup(
+                        Map.of(timeoutKey, zeroStreamId),
+                        timeoutGroupName,
+                        timeoutConsumerName,
+                        StreamReadGroupOptions.builder().block(oneSecondInMS).build())
+                    .get());
+
+            // with 0 timeout (no timeout) should never time out,
+            // but we wrap the test with timeout to avoid test failing or stuck forever
+            assertThrows(
+                TimeoutException.class, // <- future timeout, not command timeout
+                () ->
+                    testClient
+                        .xreadgroup(
+                            Map.of(timeoutKey, zeroStreamId),
+                            timeoutGroupName,
+                            timeoutConsumerName,
+                            StreamReadGroupOptions.builder().block(0L).build())
+                        .get(3, TimeUnit.SECONDS));
+        }
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3626,7 +3626,7 @@ public class SharedCommandTests {
         Map<String, String> timestamp_1_1_map = new LinkedHashMap<>();
         timestamp_1_1_map.put(field1, field1 + "1");
         String timestamp_1_1 =
-            client.xadd(key, timestamp_1_1_map, StreamAddOptions.builder().id("1-1").build()).get();
+                client.xadd(key, timestamp_1_1_map, StreamAddOptions.builder().id("1-1").build()).get();
         assertNotNull(timestamp_1_1);
 
         String groupName = "group" + UUID.randomUUID();
@@ -3635,43 +3635,43 @@ public class SharedCommandTests {
 
         // create group and consumer for the group
         assertEquals(
-            OK,
-            client
-                .xgroupCreate(
-                    key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
-                .get());
+                OK,
+                client
+                        .xgroupCreate(
+                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                        .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
 
         // Key exists, but it is not a stream
         assertEquals(OK, client.set(nonStreamKey, "bar").get());
         ExecutionException executionException =
-            assertThrows(
-                ExecutionException.class,
-                () ->
-                    client
-                        .xreadgroup(
-                            Map.of(nonStreamKey, timestamp_1_1, key, timestamp_1_1),
-                            groupName,
-                            consumerName)
-                        .get());
+                assertThrows(
+                        ExecutionException.class,
+                        () ->
+                                client
+                                        .xreadgroup(
+                                                Map.of(nonStreamKey, timestamp_1_1, key, timestamp_1_1),
+                                                groupName,
+                                                consumerName)
+                                        .get());
         assertInstanceOf(RequestException.class, executionException.getCause());
 
         executionException =
-            assertThrows(
-                ExecutionException.class,
-                () ->
-                    client
-                        .xreadgroup(
-                            Map.of(key, timestamp_1_1, nonStreamKey, timestamp_1_1),
-                            groupName,
-                            consumerName)
-                        .get());
+                assertThrows(
+                        ExecutionException.class,
+                        () ->
+                                client
+                                        .xreadgroup(
+                                                Map.of(key, timestamp_1_1, nonStreamKey, timestamp_1_1),
+                                                groupName,
+                                                consumerName)
+                                        .get());
         assertInstanceOf(RequestException.class, executionException.getCause());
 
         try (var testClient =
-                 client instanceof RedisClient
-                     ? RedisClient.CreateClient(commonClientConfig().build()).get()
-                     : RedisClusterClient.CreateClient(commonClusterClientConfig().build()).get()) {
+                client instanceof RedisClient
+                        ? RedisClient.CreateClient(commonClientConfig().build()).get()
+                        : RedisClusterClient.CreateClient(commonClusterClientConfig().build()).get()) {
             String timeoutKey = "{key}:2" + UUID.randomUUID();
             String timeoutGroupName = "group" + UUID.randomUUID();
             String timeoutConsumerName = "consumer" + UUID.randomUUID();
@@ -3708,26 +3708,26 @@ public class SharedCommandTests {
             // ensure that command doesn't time out even if timeout > request timeout
             long oneSecondInMS = 1000L;
             assertNull(
-                testClient
-                    .xreadgroup(
-                        Map.of(timeoutKey, zeroStreamId),
-                        timeoutGroupName,
-                        timeoutConsumerName,
-                        StreamReadGroupOptions.builder().block(oneSecondInMS).build())
-                    .get());
+                    testClient
+                            .xreadgroup(
+                                    Map.of(timeoutKey, ">"),
+                                    timeoutGroupName,
+                                    timeoutConsumerName,
+                                    StreamReadGroupOptions.builder().block(oneSecondInMS).build())
+                            .get());
 
             // with 0 timeout (no timeout) should never time out,
             // but we wrap the test with timeout to avoid test failing or stuck forever
             assertThrows(
-                TimeoutException.class, // <- future timeout, not command timeout
-                () ->
-                    testClient
-                        .xreadgroup(
-                            Map.of(timeoutKey, zeroStreamId),
-                            timeoutGroupName,
-                            timeoutConsumerName,
-                            StreamReadGroupOptions.builder().block(0L).build())
-                        .get(3, TimeUnit.SECONDS));
+                    TimeoutException.class, // <- future timeout, not command timeout
+                    () ->
+                            testClient
+                                    .xreadgroup(
+                                            Map.of(timeoutKey, ">"),
+                                            timeoutGroupName,
+                                            timeoutConsumerName,
+                                            StreamReadGroupOptions.builder().block(0L).build())
+                                    .get(3, TimeUnit.SECONDS));
         }
     }
 

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -38,7 +38,6 @@ import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange.IdBound;
-import glide.api.models.commands.stream.StreamReadGroupOptions;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions.MinId;
 import java.util.HashMap;
@@ -747,9 +746,9 @@ public class TransactionTestUtilities {
                 .xgroupCreate(
                         streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
                 .xgroupCreateConsumer(streamKey1, groupName1, consumer1)
-//                .xreadgroup(Map.of(streamKey1, "0-2"), groupName1, consumer1)
-//                .xreadgroup(Map.of(streamKey1, "0-2"), groupName1, consumer1,
-//                    StreamReadGroupOptions.builder().count(2L).build())
+                //                .xreadgroup(Map.of(streamKey1, "0-2"), groupName1, consumer1)
+                //                .xreadgroup(Map.of(streamKey1, "0-2"), groupName1, consumer1,
+                //                    StreamReadGroupOptions.builder().count(2L).build())
                 .xgroupDelConsumer(streamKey1, groupName1, consumer1)
                 .xgroupDestroy(streamKey1, groupName1)
                 .xgroupDestroy(streamKey1, groupName2)
@@ -760,12 +759,12 @@ public class TransactionTestUtilities {
             "0-2", // xadd(streamKey1, Map.of("field2", "value2"), ... .id("0-2").build());
             "0-3", // xadd(streamKey1, Map.of("field3", "value3"), ... .id("0-3").build());
             3L, // xlen(streamKey1)
-//            Map.of(
-//                    streamKey1,
-//                    Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9, "0-2"));
-//            Map.of(
-//                streamKey1,
-//                Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9, "0-2"), options);
+            Map.of(
+                    streamKey1,
+                    Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9, "0-2"));
+            Map.of(
+                    streamKey1, Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9,
+            // "0-2"), options);
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrange(streamKey1, "0-1", "0-1")
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrange(streamKey1, "0-1", "0-1", 1l)
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrevrange(streamKey1, "0-1", "0-1")
@@ -775,12 +774,21 @@ public class TransactionTestUtilities {
             OK, // xgroupCreate(streamKey1, groupName1, "0-0")
             OK, // xgroupCreate(streamKey1, groupName1, "0-0", options)
             true, // xgroupCreateConsumer(streamKey1, groupName1, consumer1)
-            Map.of(
-                streamKey1,
-                Map.of("0-3", new String[][] {{"field3", "value3"}})), // xreadgroup(Map.of(key9, "0-2"), groupName1, consumer1);
-            Map.of(
-                streamKey1,
-                Map.of("0-3", new String[][] {{"field3", "value3"}})), // xreadgroup(Map.of(key9, "0-2"), groupName1, consumer1, options);
+            //            Map.of(
+            //                    streamKey1,
+            //                    Map.of(
+            //                            "0-3",
+            //                            new String[][] {
+            //                                {"field3", "value3"}
+            //                            })), // xreadgroup(Map.of(key9, "0-2"), groupName1, consumer1);
+            //            Map.of(
+            //                    streamKey1,
+            //                    Map.of(
+            //                            "0-3",
+            //                            new String[][] {
+            //                                {"field3", "value3"}
+            //                            })), // xreadgroup(Map.of(key9, "0-2"), groupName1, consumer1,
+            // options);
             0L, // xgroupDelConsumer(streamKey1, groupName1, consumer1)
             true, // xgroupDestroy(streamKey1, groupName1)
             true, // xgroupDestroy(streamKey1, groupName2)

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -38,6 +38,8 @@ import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange.IdBound;
+import glide.api.models.commands.stream.StreamReadGroupOptions;
+import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions.MinId;
 import java.util.HashMap;
 import java.util.Map;
@@ -735,6 +737,7 @@ public class TransactionTestUtilities {
                 .xadd(streamKey1, Map.of("field3", "value3"), StreamAddOptions.builder().id("0-3").build())
                 .xlen(streamKey1)
                 .xread(Map.of(streamKey1, "0-2"))
+                .xread(Map.of(streamKey1, "0-2"), StreamReadOptions.builder().count(1L).build())
                 .xrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"))
                 .xrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"), 1L)
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"))
@@ -744,6 +747,9 @@ public class TransactionTestUtilities {
                 .xgroupCreate(
                         streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
                 .xgroupCreateConsumer(streamKey1, groupName1, consumer1)
+//                .xreadgroup(Map.of(streamKey1, "0-2"), groupName1, consumer1)
+//                .xreadgroup(Map.of(streamKey1, "0-2"), groupName1, consumer1,
+//                    StreamReadGroupOptions.builder().count(2L).build())
                 .xgroupDelConsumer(streamKey1, groupName1, consumer1)
                 .xgroupDestroy(streamKey1, groupName1)
                 .xgroupDestroy(streamKey1, groupName2)
@@ -754,9 +760,12 @@ public class TransactionTestUtilities {
             "0-2", // xadd(streamKey1, Map.of("field2", "value2"), ... .id("0-2").build());
             "0-3", // xadd(streamKey1, Map.of("field3", "value3"), ... .id("0-3").build());
             3L, // xlen(streamKey1)
-            Map.of(
-                    streamKey1,
-                    Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9, "0-2"));
+//            Map.of(
+//                    streamKey1,
+//                    Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9, "0-2"));
+//            Map.of(
+//                streamKey1,
+//                Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9, "0-2"), options);
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrange(streamKey1, "0-1", "0-1")
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrange(streamKey1, "0-1", "0-1", 1l)
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrevrange(streamKey1, "0-1", "0-1")
@@ -766,6 +775,12 @@ public class TransactionTestUtilities {
             OK, // xgroupCreate(streamKey1, groupName1, "0-0")
             OK, // xgroupCreate(streamKey1, groupName1, "0-0", options)
             true, // xgroupCreateConsumer(streamKey1, groupName1, consumer1)
+            Map.of(
+                streamKey1,
+                Map.of("0-3", new String[][] {{"field3", "value3"}})), // xreadgroup(Map.of(key9, "0-2"), groupName1, consumer1);
+            Map.of(
+                streamKey1,
+                Map.of("0-3", new String[][] {{"field3", "value3"}})), // xreadgroup(Map.of(key9, "0-2"), groupName1, consumer1, options);
             0L, // xgroupDelConsumer(streamKey1, groupName1, consumer1)
             true, // xgroupDestroy(streamKey1, groupName1)
             true, // xgroupDestroy(streamKey1, groupName2)

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -38,6 +38,7 @@ import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange.IdBound;
+import glide.api.models.commands.stream.StreamReadGroupOptions;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions.MinId;
 import java.util.HashMap;
@@ -742,13 +743,16 @@ public class TransactionTestUtilities {
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"))
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"), 1L)
                 .xtrim(streamKey1, new MinId(true, "0-2"))
-                .xgroupCreate(streamKey1, groupName1, "0-0")
+                .xgroupCreate(streamKey1, groupName1, "0-2")
                 .xgroupCreate(
                         streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
                 .xgroupCreateConsumer(streamKey1, groupName1, consumer1)
-                //                .xreadgroup(Map.of(streamKey1, "0-2"), groupName1, consumer1)
-                //                .xreadgroup(Map.of(streamKey1, "0-2"), groupName1, consumer1,
-                //                    StreamReadGroupOptions.builder().count(2L).build())
+                .xreadgroup(Map.of(streamKey1, ">"), groupName1, consumer1)
+                .xreadgroup(
+                        Map.of(streamKey1, "0-3"),
+                        groupName1,
+                        consumer1,
+                        StreamReadGroupOptions.builder().count(2L).build())
                 .xgroupDelConsumer(streamKey1, groupName1, consumer1)
                 .xgroupDestroy(streamKey1, groupName1)
                 .xgroupDestroy(streamKey1, groupName2)
@@ -763,8 +767,10 @@ public class TransactionTestUtilities {
                     streamKey1,
                     Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9, "0-2"));
             Map.of(
-                    streamKey1, Map.of("0-3", new String[][] {{"field3", "value3"}})), // xread(Map.of(key9,
-            // "0-2"), options);
+                    streamKey1,
+                    Map.of(
+                            "0-3",
+                            new String[][] {{"field3", "value3"}})), // xread(Map.of(key9, "0-2"), options);
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrange(streamKey1, "0-1", "0-1")
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrange(streamKey1, "0-1", "0-1", 1l)
             Map.of("0-1", new String[][] {{"field1", "value1"}}), // .xrevrange(streamKey1, "0-1", "0-1")
@@ -774,22 +780,17 @@ public class TransactionTestUtilities {
             OK, // xgroupCreate(streamKey1, groupName1, "0-0")
             OK, // xgroupCreate(streamKey1, groupName1, "0-0", options)
             true, // xgroupCreateConsumer(streamKey1, groupName1, consumer1)
-            //            Map.of(
-            //                    streamKey1,
-            //                    Map.of(
-            //                            "0-3",
-            //                            new String[][] {
-            //                                {"field3", "value3"}
-            //                            })), // xreadgroup(Map.of(key9, "0-2"), groupName1, consumer1);
-            //            Map.of(
-            //                    streamKey1,
-            //                    Map.of(
-            //                            "0-3",
-            //                            new String[][] {
-            //                                {"field3", "value3"}
-            //                            })), // xreadgroup(Map.of(key9, "0-2"), groupName1, consumer1,
-            // options);
-            0L, // xgroupDelConsumer(streamKey1, groupName1, consumer1)
+            Map.of(
+                    streamKey1,
+                    Map.of(
+                            "0-3",
+                            new String[][] {
+                                {"field3", "value3"}
+                            })), // xreadgroup(Map.of(streamKey1, ">"), groupName1, consumer1);
+            Map.of(
+                    streamKey1,
+                    Map.of()), // xreadgroup(Map.of(streamKey1, ">"), groupName1, consumer1, options);
+            1L, // xgroupDelConsumer(streamKey1, groupName1, consumer1)
             true, // xgroupDestroy(streamKey1, groupName1)
             true, // xgroupDestroy(streamKey1, groupName2)
             1L, // .xdel(streamKey1, new String[] {"0-1", "0-5"});

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -81,10 +81,6 @@ public class ClusterTransactionTests {
         Object[] expectedResult = builder.apply(transaction);
 
         Object[] results = clusterClient.exec(transaction).get();
-        if (testName.equals("Stream Commands")) {
-            System.out.println(expectedResult[14] + " <=> " + results[14]);
-            System.out.println(expectedResult[15] + " <=> " + results[15]);
-        }
         assertDeepEquals(expectedResult, results);
     }
 

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -81,6 +81,10 @@ public class ClusterTransactionTests {
         Object[] expectedResult = builder.apply(transaction);
 
         Object[] results = clusterClient.exec(transaction).get();
+        if (testName.equals("Stream Commands")) {
+            System.out.println(expectedResult[14] + " <=> " + results[14]);
+            System.out.println(expectedResult[15] + " <=> " + results[15]);
+        }
         assertDeepEquals(expectedResult, results);
     }
 


### PR DESCRIPTION
Dependent on https://github.com/aws/glide-for-redis/pull/1599/

Adds the [XREADGROUP](https://valkey.io/commands/xreadgroup/) command to Java

TODO: 

- [X] Fix IT tests for XREADGROUP
- [x] Fix IT test for failure/blocking cases