### PR TITLE
Add DISABLED log level for Python and Node clients

### DIFF
--- a/node/src/Logger.ts
+++ b/node/src/Logger.ts
@@ -12,7 +12,7 @@ const LEVEL: Map<LevelOptions | undefined, Level | undefined> = new Map([
     ["trace", Level.Trace],
     [undefined, undefined],
 ]);
-type LevelOptions = "error" | "warn" | "info" | "debug" | "trace";
+type LevelOptions = "disabled" | "error" | "warn" | "info" | "debug" | "trace";
 
 /*
  * A singleton class that allows logging which is consistent with logs from the internal rust core.
@@ -26,7 +26,7 @@ export class Logger {
     private static logger_level = 0;
 
     private constructor(level?: LevelOptions, fileName?: string) {
-        Logger.logger_level = InitInternalLogger(LEVEL.get(level), fileName);
+        Logger.logger_level = level == "disabled" ? -1 : InitInternalLogger(LEVEL.get(level), fileName);
     }
 
     /**
@@ -45,6 +45,8 @@ export class Logger {
         if (!Logger._instance) {
             new Logger();
         }
+
+        if (logLevel == "disabled") return;
 
         const level = LEVEL.get(logLevel) || 0;
         if (!(level <= Logger.logger_level)) return;

--- a/python/python/glide/logger.py
+++ b/python/python/glide/logger.py
@@ -10,6 +10,7 @@ from .glide import py_init, py_log
 
 
 class Level(Enum):
+    DISABLED = -1
     ERROR = internalLevel.Error
     WARN = internalLevel.Warn
     INFO = internalLevel.Info
@@ -32,6 +33,9 @@ class Logger:
     logger_level: internalLevel
 
     def __init__(self, level: Optional[Level] = None, file_name: Optional[str] = None):
+        if level and level.value = Level.DISABLED:
+            Logger.logger_level = level.value
+            return
         level_value = level.value if level else None
         Logger.logger_level = py_init(level_value, file_name)
 
@@ -63,6 +67,10 @@ class Logger:
         """
         if not cls._instance:
             cls._instance = cls(None)
+        
+        if log_level.value is Level.DISABLED:
+            return
+
         if not log_level.value.is_lower(Logger.logger_level):
             return
         py_log(log_level.value, log_identifier, message)


### PR DESCRIPTION
I haven't tested this yet. I'm just making this now to address https://github.com/aws/glide-for-redis/pull/1422/files#r1606530226 and so I can make sure this doesn't fall through the cracks.