### PR TITLE
Java: Ignores VSCode-created `bin` directories

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -9,3 +9,6 @@ protobuf
 
 # Must be ignored as part of Maven Central publishing process
 gradle.properties
+
+# Ignore VSCode JUnit extension directories
+bin/


### PR DESCRIPTION
The VSCode [Extension Pack for Java](https://code.visualstudio.com/docs/java/java-testing) includes JUnit support that may automatically create various `bin` folders and `junit-platform.properties` files. Based on personal experience, these can be created soon after cloning the repo, resulting in mysterious uncommitted file. Since VSCode and the Extension Pack for Java are likely to be widely used, it seems simplest to simply ignore everything in the `bin/` folders that get created.